### PR TITLE
fix: use artifacts_dir for NTFF path in BaremetalExecutor.run

### DIFF
--- a/nkipy/src/nkipy/runtime/baremetal_executor.py
+++ b/nkipy/src/nkipy/runtime/baremetal_executor.py
@@ -152,7 +152,11 @@ class BaremetalExecutor:
         )
 
         # Use SpikeModel's __call__ method
-        ntff_name = os.path.abspath("./profile.ntff") if save_trace else None
+        if save_trace:
+            base = os.path.abspath(artifacts_dir) if artifacts_dir else os.getcwd()
+            ntff_name = os.path.join(base, "profile.ntff")
+        else:
+            ntff_name = None
         device_kernel(
             inputs=inputs, outputs=outputs, save_trace=save_trace, ntff_name=ntff_name
         )


### PR DESCRIPTION
## Summary
- `BaremetalExecutor.run()` accepts an `artifacts_dir` parameter but ignores it, always writing the NTFF trace to `$CWD/profile.ntff`
- Callers passing `artifacts_dir` expect the NTFF at `{artifacts_dir}/profile.ntff`, but the file lands in CWD instead
- This causes NTFF files to be missing from their expected location

## Fix
Use `artifacts_dir` when provided; fall back to `os.getcwd()` when it is `None` (preserving existing default behavior).

## Test plan
- [x] Verified NTFF files are written to `artifacts_dir` when provided
- [x] Verified NTFF falls back to CWD when `artifacts_dir` is `None`
- [x] Kernel correctness unaffected