### PR TITLE
feat(spike): add device-side timing via system trace API

### DIFF
--- a/nkipy/src/nkipy/runtime/baremetal_executor.py
+++ b/nkipy/src/nkipy/runtime/baremetal_executor.py
@@ -84,6 +84,7 @@ class BaremetalExecutor:
         *args,
         warmup_iterations: int = 5,
         benchmark_iterations: int = 100,
+        mode: str = "device",
         artifacts_dir: Optional[str] = None,
         **kwargs,
     ) -> Dict[str, float]:
@@ -95,6 +96,7 @@ class BaremetalExecutor:
             kwargs: Keyword arguments to pass to the kernel
             warmup_iterations: Number of warmup iterations
             benchmark_iterations: Number of benchmark iterations
+            mode: Timing mode ('device' or 'host')
             artifacts_dir: Optional directory for artifacts
 
         Returns:
@@ -117,6 +119,7 @@ class BaremetalExecutor:
             outputs=outputs,
             warmup_iter=warmup_iterations,
             benchmark_iter=benchmark_iterations,
+            mode=mode,
         )
         return stats
 

--- a/spike/CMakeLists.txt
+++ b/spike/CMakeLists.txt
@@ -48,6 +48,7 @@ set(SOURCES
     src/tensor_set.cpp
     src/model.cpp
     src/spike.cpp
+    src/sys_trace.cpp
     src/python_bindings.cpp
 )
 

--- a/spike/README.md
+++ b/spike/README.md
@@ -172,9 +172,6 @@ spike.tensor_read_to_pybuffer(tensor, buffer, offset=0, size=0)
 # Execution (releases GIL for CC support)
 spike.execute(model, inputs: Dict[str, NrtTensor], outputs: Dict[str, NrtTensor],
            ntff_name: str = None, save_trace: bool = False)
-
-# Benchmarking
-spike.benchmark(model, inputs, outputs, warmup_iterations=1, benchmark_iterations=1) -> BenchmarkResult
 ```
 
 ### High-Level API: SpikeTensor and SpikeModel
@@ -237,6 +234,7 @@ results = model.benchmark(
     outputs={"output": output_tensor}, # optional
     warmup_iter=5,
     benchmark_iter=100
+    mode="device", # device or host overhead measurement
 )
 
 print(f"Mean execution time: {results.mean_ms:.2f} ms")
@@ -281,6 +279,4 @@ except SpikeError as e:
 
 ### Future Work
 
-- [ ] **Improved benchmarking**: Integrate libnrt inspect APIs for device-side latency measurement
-- [ ] **Kernel switch overhead**: Add option to measure kernel switching costs
 - [ ] **NKI debugger integration**: Support for debugging NKI kernels via Spike

--- a/spike/src/include/spike.h
+++ b/spike/src/include/spike.h
@@ -6,23 +6,12 @@
 #include "model.h"
 #include "nrt_wrapper.h"
 #include "tensor.h"
-#include <chrono>
 #include <memory>
 #include <optional>
 #include <unordered_map>
 #include <vector>
 
 namespace spike {
-
-// Benchmark result structure
-struct BenchmarkResult {
-  double mean_ms;
-  double min_ms;
-  double max_ms;
-  double std_dev_ms;
-  size_t iterations;
-  size_t warmup_iterations;
-};
 
 // Tensor metadata structure
 struct TensorMetadata {
@@ -84,12 +73,6 @@ public:
                const std::unordered_map<std::string, NrtTensor &> &outputs,
                std::optional<std::string> ntff_name = std::nullopt,
                bool save_trace = false);
-
-  BenchmarkResult
-  benchmark(NrtModel &model,
-            const std::unordered_map<std::string, NrtTensor &> &inputs,
-            const std::unordered_map<std::string, NrtTensor &> &outputs,
-            size_t warmup_iterations = 1, size_t benchmark_iterations = 1);
 
   // Model introspection
   ModelTensorInfo get_tensor_info(NrtModel &model);

--- a/spike/src/include/sys_trace.h
+++ b/spike/src/include/sys_trace.h
@@ -1,0 +1,45 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+#ifndef SPIKE_SRC_INCLUDE_SYS_TRACE_H
+#define SPIKE_SRC_INCLUDE_SYS_TRACE_H
+
+#include "error.h"
+#include <nrt/nrt_sys_trace.h>
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+namespace spike {
+
+// RAII wrapper for NRT system trace capture.
+// If core_id is given, traces that single core.
+// If omitted, traces all visible NeuronCores.
+class SysTraceGuard {
+public:
+  explicit SysTraceGuard(std::optional<uint32_t> core_id = std::nullopt);
+  ~SysTraceGuard();
+
+  // Non-copyable, non-movable
+  SysTraceGuard(const SysTraceGuard &) = delete;
+  SysTraceGuard &operator=(const SysTraceGuard &) = delete;
+  SysTraceGuard(SysTraceGuard &&) = delete;
+  SysTraceGuard &operator=(SysTraceGuard &&) = delete;
+
+  // Stop tracing (idempotent). Called automatically by destructor.
+  void stop();
+
+  // Fetch events as JSON string, consumes events from the ring buffer
+  std::string fetch_events_json();
+
+  // Fetch and discard events (clears the ring buffer)
+  void drain_events();
+
+private:
+  std::optional<uint32_t> core_id_;
+  bool started_;
+};
+
+} // namespace spike
+
+#endif // SPIKE_SRC_INCLUDE_SYS_TRACE_H

--- a/spike/src/spike/__init__.py
+++ b/spike/src/spike/__init__.py
@@ -1,16 +1,16 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 from ._spike import (
-    BenchmarkResult,
     ModelTensorInfo,
     NrtError,
     NrtModel,
     NrtTensor,
     SpikeError,
+    SystemTraceSession,
     TensorMetadata,
 )
 from .profiler_adapter import SpikeProfiler
-from .spike_model import SpikeModel
+from .spike_model import BenchmarkResult, SpikeModel
 from .spike_singleton import configure, get_spike_singleton, reset
 from .spike_tensor import SpikeTensor
 
@@ -23,6 +23,7 @@ __all__ = [
     "get_spike_singleton",
     "NrtError",
     "SpikeError",
+    "SystemTraceSession",
     "BenchmarkResult",
     "ModelTensorInfo",
     "NrtModel",

--- a/spike/src/spike/_spike.pyi
+++ b/spike/src/spike/_spike.pyi
@@ -11,32 +11,25 @@ class SpikeError(SpikeRuntimeError):
 class NrtError(SpikeRuntimeError):
     pass
 
-class BenchmarkResult:
-    @property
-    def mean_ms(self) -> float:
-        """Mean execution time in milliseconds"""
+class SystemTraceSession:
+    def __init__(self, core_id: int | None = None) -> None:
+        """
+        Create a trace session. Trace the given core_id or if core_id is omitted, traces all visible NeuronCores.
+        """
 
-    @property
-    def min_ms(self) -> float:
-        """Minimum execution time in milliseconds"""
+    def stop(self) -> None:
+        """Stop tracing. Called automatically on __exit__."""
 
-    @property
-    def max_ms(self) -> float:
-        """Maximum execution time in milliseconds"""
+    def fetch_events_json(self) -> str:
+        """
+        Fetch events as JSON string, consumes events from the system trace ring buffer
+        """
 
-    @property
-    def std_dev_ms(self) -> float:
-        """Standard deviation in milliseconds"""
+    def drain_events(self) -> None:
+        """Discard events in the buffer"""
 
-    @property
-    def iterations(self) -> int:
-        """Number of benchmark iterations"""
-
-    @property
-    def warmup_iterations(self) -> int:
-        """Number of warmup iterations"""
-
-    def __repr__(self) -> str: ...
+    def __enter__(self) -> SystemTraceSession: ...
+    def __exit__(self, *args) -> None: ...
 
 class TensorMetadata:
     @property
@@ -133,16 +126,6 @@ class Spike:
         save_trace: bool | None = False,
     ) -> None:
         """Execute a model with given inputs and outputs"""
-
-    def benchmark(
-        self,
-        model: NrtModel,
-        inputs: Mapping[str, NrtTensor],
-        outputs: Mapping[str, NrtTensor],
-        warmup_iterations: int = 1,
-        benchmark_iterations: int = 1,
-    ) -> BenchmarkResult:
-        """Benchmark a model execution"""
 
     def allocate_tensor(
         self, size: int, core_id: int = 0, name: str | None = None

--- a/spike/src/spike/spike_model.py
+++ b/spike/src/spike/spike_model.py
@@ -1,17 +1,104 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+import json
+import math
+import time
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional
 
 import numpy as np
 from ml_dtypes import bfloat16, float8_e4m3, float8_e5m2
 
-from ._spike import NrtModel
+from ._spike import NrtModel, SystemTraceSession
 from .logger import get_logger
 from .spike_singleton import get_spike_singleton
 from .spike_tensor import SpikeTensor
 
 logger = get_logger()
+
+
+@dataclass
+class BenchmarkResult:
+    """Result of a model benchmark run."""
+
+    mean_ms: float
+    min_ms: float
+    max_ms: float
+    std_dev_ms: float
+    iterations: int
+    warmup_iterations: int
+    durations_ms: list[float] = field(default_factory=list)
+
+    def __repr__(self) -> str:
+        return (
+            f"BenchmarkResult(mean={self.mean_ms:.4f}ms, "
+            f"min={self.min_ms:.4f}ms, "
+            f"max={self.max_ms:.4f}ms, "
+            f"std_dev={self.std_dev_ms:.4f}ms, "
+            f"iterations={self.iterations}, "
+            f"warmup_iterations={self.warmup_iterations})"
+        )
+
+
+def _parse_trace_durations(events_json: str) -> list[float]:
+    """Parse device execution durations from NRT sys trace JSON.
+
+    Returns:
+        List of execution durations in milliseconds.
+    """
+    if not events_json:
+        return []
+
+    root = json.loads(events_json)
+    events = root.get("events", [])
+
+    DEVICE_EXECUTE_TYPE = "nc_exec_running"
+
+    # nc_exec_running start timestamps keyed by tracking_id
+    starts: dict[int, int] = {}
+    durations_ms: list[float] = []
+
+    for event in events:
+        if event.get("event_type") != DEVICE_EXECUTE_TYPE:
+            continue
+
+        phase = event.get("phase")
+        tracking_id = event.get("tracking_id")
+        data = event.get("data", {})
+        nc_ts = data.get("nc_timestamp_ns")
+
+        if nc_ts is None or tracking_id is None:
+            continue
+
+        if phase == "start":
+            starts[tracking_id] = nc_ts
+        elif phase == "stop":
+            start_ts = starts.pop(tracking_id, None)
+            if start_ts is not None:
+                durations_ms.append((nc_ts - start_ts) / 1_000_000.0)
+
+    return durations_ms
+
+
+def _make_benchmark_result(
+    durations_ms: list[float], warmup_iterations: int
+) -> "BenchmarkResult":
+    """Compute statistics from a list of durations in milliseconds."""
+    n = len(durations_ms)
+    mean = sum(durations_ms) / n
+    min_val = min(durations_ms)
+    max_val = max(durations_ms)
+    variance = sum((d - mean) ** 2 for d in durations_ms) / n
+    return BenchmarkResult(
+        mean_ms=mean,
+        min_ms=min_val,
+        max_ms=max_val,
+        std_dev_ms=math.sqrt(variance),
+        iterations=n,
+        warmup_iterations=warmup_iterations,
+        durations_ms=list(durations_ms),
+    )
 
 
 class SpikeModel:
@@ -188,7 +275,8 @@ class SpikeModel:
         outputs: Dict[str, SpikeTensor] = None,
         warmup_iter=5,
         benchmark_iter=5,
-    ):
+        mode: str = "device",
+    ) -> BenchmarkResult:
         """Benchmark the model execution.
 
         Args:
@@ -196,24 +284,62 @@ class SpikeModel:
             outputs: Dict[str, SpikeTensor]. Key needs to match neff output name.
             warmup_iter: Number of warmup iterations
             benchmark_iter: Number of benchmark iterations
+            mode: Timing mode.
+                'device' — NeuronCore execution time via device-side trace
+                           (nc_exec_running, device clock). Most accurate for
+                           kernel timing.
+                'host'   — Host wall-clock time. Includes all host-device
+                           overhead. No tracing overhead.
 
         Returns:
-            Benchmark results from spike
+            BenchmarkResult with mean_ms, min_ms, max_ms, std_dev_ms,
+            iterations, warmup_iterations, durations_ms.
         """
+        if mode not in ("device", "host"):
+            raise ValueError(
+                f"Invalid benchmark mode '{mode}'. Use 'device' or 'host'."
+            )
+
         if outputs is None:
             output_tensors = self.allocate_output_tensors()
             outputs = {tensor.name: tensor for tensor in output_tensors}
 
         self._validate_io(inputs, outputs)
 
-        inputs = {k: v.tensor_ref for k, v in inputs.items()}
-        outputs = {k: v.tensor_ref for k, v in outputs.items()}
+        input_refs = {k: v.tensor_ref for k, v in inputs.items()}
+        output_refs = {k: v.tensor_ref for k, v in outputs.items()}
+        spike = get_spike_singleton()
 
         logger.info(f"Benchmarking model: {self.model_ref}")
-        return get_spike_singleton().benchmark(
-            self.model_ref,
-            inputs=inputs,
-            outputs=outputs,
-            warmup_iterations=warmup_iter,
-            benchmark_iterations=benchmark_iter,
-        )
+
+        if mode == "device":
+            with SystemTraceSession(self.model_ref.core_id) as trace:
+                for _ in range(warmup_iter):
+                    spike.execute(self.model_ref, input_refs, output_refs)
+                trace.drain_events()
+
+                for _ in range(benchmark_iter):
+                    spike.execute(self.model_ref, input_refs, output_refs)
+
+                events_json = trace.fetch_events_json()
+
+            durations_ms = _parse_trace_durations(events_json)
+            if not durations_ms:
+                raise RuntimeError(
+                    "No nc_exec_running events captured during benchmark. "
+                    "Cannot compute device-side timing."
+                )
+            return _make_benchmark_result(durations_ms, warmup_iter)
+
+        # Host mode: wall-clock timing
+        for _ in range(warmup_iter):
+            spike.execute(self.model_ref, input_refs, output_refs)
+
+        durations_ms = []
+        for _ in range(benchmark_iter):
+            start = time.perf_counter()
+            spike.execute(self.model_ref, input_refs, output_refs)
+            elapsed = time.perf_counter() - start
+            durations_ms.append(elapsed * 1000.0)
+
+        return _make_benchmark_result(durations_ms, warmup_iter)

--- a/spike/src/sys_trace.cpp
+++ b/spike/src/sys_trace.cpp
@@ -1,0 +1,106 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+#include "sys_trace.h"
+
+namespace spike {
+
+SysTraceGuard::SysTraceGuard(std::optional<uint32_t> core_id)
+    : core_id_(core_id), started_(false) {
+  nrt_sys_trace_config_t *config = nullptr;
+  NRT_STATUS status = nrt_sys_trace_config_allocate(&config);
+  if (status != NRT_SUCCESS) {
+    throw NrtError(status, "Failed to allocate sys trace config");
+  }
+
+  if (core_id_.has_value()) {
+    nrt_sys_trace_config_set_capture_enabled_for_nc(config,
+                                                    core_id_.value(), true);
+  }
+  // When core_id is not set the default config captures all cores.
+
+  status = nrt_sys_trace_start(config);
+  nrt_sys_trace_config_free(config);
+
+  if (status != NRT_SUCCESS) {
+    throw NrtError(status, "Failed to start sys trace");
+  }
+
+  started_ = true;
+}
+
+SysTraceGuard::~SysTraceGuard() { stop(); }
+
+void SysTraceGuard::stop() {
+  if (started_) {
+    nrt_sys_trace_stop();
+    started_ = false;
+  }
+}
+
+std::string SysTraceGuard::fetch_events_json() {
+  if (!started_) {
+    throw SpikeError("Cannot fetch events: sys trace is not started");
+  }
+
+  nrt_sys_trace_fetch_options_t *options = nullptr;
+  NRT_STATUS status = nrt_sys_trace_fetch_options_allocate(&options);
+  if (status != NRT_SUCCESS) {
+    throw NrtError(status, "Failed to allocate fetch options");
+  }
+
+  if (core_id_.has_value()) {
+    nrt_sys_trace_fetch_options_set_nc_idx(options, core_id_.value());
+  }
+  // When core_id is not set we skip set_nc_idx so NRT returns all cores.
+
+  char *buffer = nullptr;
+  size_t written_size = 0;
+  status = nrt_sys_trace_fetch_events(&buffer, &written_size, options);
+  nrt_sys_trace_fetch_options_free(options);
+
+  if (status != NRT_SUCCESS) {
+    if (buffer) {
+      nrt_sys_trace_buffer_free(buffer);
+    }
+    throw NrtError(status, "Failed to fetch trace events");
+  }
+
+  std::string result;
+  if (buffer && written_size > 0) {
+    result.assign(buffer, written_size);
+    nrt_sys_trace_buffer_free(buffer);
+  }
+
+  return result;
+}
+
+void SysTraceGuard::drain_events() {
+  if (!started_) {
+    throw SpikeError("Cannot drain events: sys trace is not started");
+  }
+
+  nrt_sys_trace_fetch_options_t *options = nullptr;
+  NRT_STATUS status = nrt_sys_trace_fetch_options_allocate(&options);
+  if (status != NRT_SUCCESS) {
+    throw NrtError(status, "Failed to allocate fetch options");
+  }
+
+  if (core_id_.has_value()) {
+    nrt_sys_trace_fetch_options_set_nc_idx(options, core_id_.value());
+  }
+
+  char *buffer = nullptr;
+  size_t written_size = 0;
+  status = nrt_sys_trace_fetch_events(&buffer, &written_size, options);
+  nrt_sys_trace_fetch_options_free(options);
+
+  if (buffer) {
+    nrt_sys_trace_buffer_free(buffer);
+  }
+
+  if (status != NRT_SUCCESS) {
+    throw NrtError(status, "Failed to drain trace events");
+  }
+}
+
+} // namespace spike

--- a/tests/integration/test_device_kernel_tensor.py
+++ b/tests/integration/test_device_kernel_tensor.py
@@ -166,11 +166,18 @@ class TestDeviceKernelTensor:
             benchmark_iter=3,
         )
 
-        # Verify values are reasonable
+        # Verify execution time values are reasonable
         assert stats.mean_ms > 0
         assert stats.min_ms > 0
         assert stats.max_ms >= stats.min_ms
         assert stats.std_dev_ms >= 0
+        assert stats.iterations == 3
+        assert stats.warmup_iterations == 2
+
+        # Verify raw per-iteration durations
+        assert isinstance(stats.durations_ms, list)
+        assert len(stats.durations_ms) == 3
+        assert all(d > 0 for d in stats.durations_ms)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Replace host-side benchmarking with device-side latency measurement using libnrt's system trace inspection APIs.
*Description of changes:*

- Add SystemTraceSession class for capturing device execution events
- Implement sys_trace.cpp with NRT inspect API integration
- Update SpikeModel.benchmark() to use device or host timing modes
- Add BenchmarkResult dataclass with detailed statistics
- Remove deprecated C++ BenchmarkResult and benchmark() method
- Pass timing mode parameter through baremetal executor



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
