### PR TITLE
feat(spike): Expose tensor virtual address for p2p weight transfer

### DIFF
--- a/spike/src/include/tensor.h
+++ b/spike/src/include/tensor.h
@@ -25,6 +25,9 @@ public:
   uint32_t get_core_id() const { return core_id_; }
   uint64_t get_size() const { return size_; }
   const std::string &get_name() const { return name_; }
+  uintptr_t get_va() const {
+    return ptr_ ? reinterpret_cast<uintptr_t>(nrt_tensor_get_va(ptr_)) : 0;
+  }
   bool is_freed() const;
   bool is_owner() const { return spike_ != nullptr; }
 

--- a/spike/src/python_bindings.cpp
+++ b/spike/src/python_bindings.cpp
@@ -83,7 +83,9 @@ NB_MODULE(_spike, m) {
   nb::class_<NrtTensor>(m, "NrtTensor")
       .def_prop_ro("core_id", &NrtTensor::get_core_id, "Logical NeuronCore ID")
       .def_prop_ro("size", &NrtTensor::get_size, "Tensor size in bytes")
-      .def_prop_ro("name", &NrtTensor::get_name, "Tensor name");
+      .def_prop_ro("name", &NrtTensor::get_name, "Tensor name")
+      .def_prop_ro("va", &NrtTensor::get_va,
+                   "CPU-accessible virtual address of device HBM memory");
 
   // NrtModel class
   nb::class_<NrtModel>(m, "NrtModel")

--- a/spike/src/spike/_spike.pyi
+++ b/spike/src/spike/_spike.pyi
@@ -72,6 +72,10 @@ class NrtTensor:
     def name(self) -> str:
         """Tensor name"""
 
+    @property
+    def va(self) -> int:
+        """CPU-accessible virtual address of device HBM memory"""
+
 class NrtModel:
     @property
     def neff_path(self) -> str:


### PR DESCRIPTION
Description:

This PR adds a va (virtual address) property to NrtTensor, exposing the CPU-accessible virtual address of device HBM memory. This is a prerequisite for enabling peer-to-
peer weight transfer between NeuronCores.

Changes:

- spike/src/include/tensor.h — Added get_va() method that returns the virtual address of the underlying NRT tensor via nrt_tensor_get_va(), or 0 if the pointer is null.
- spike/src/python_bindings.cpp — Exposed get_va() as a read-only va property on the NrtTensor Python binding.
- spike/src/spike/_spike.pyi — Added type stub for the va property (int).

Testing:

P2p weight transfer was validated on the sleep_mode branch with end-to-end tests across NeuronCores.