### PR TITLE
fix: clamp gather indices in diag 1D→2D for non-zero k

### DIFF
--- a/nkipy/src/nkipy/core/ops/creation.py
+++ b/nkipy/src/nkipy/core/ops/creation.py
@@ -527,6 +527,11 @@ def _diag_hlo(v, k=0):
             # Diagonal starts at row -k: raw col index gives position in v
             idx_ref = NKIPyTensorRef(col_iota)
 
+        # Clamp indices to valid range — out-of-bounds positions are zeroed by the mask
+        from nkipy.core.ops.unary import clip
+
+        idx_ref = clip(idx_ref, 0, v_bt.shape[0] - 1)
+
         # Use take to gather v values at idx positions, then mask
         from nkipy.core.ops.indexing import take
 


### PR DESCRIPTION
## Summary
- When `k != 0`, `np.diag` (1D→2D path) builds an `(n, n)` output where `n = len(v) + |k|`, but the iota gather indices range `[0, n)` while `v` only has `len(v)` elements
- The compiler rejects the out-of-bounds gather even though those positions are masked to zero by `where(diag_mask, ...)`
- Fix: clamp `idx_ref` to `[0, len(v) - 1]` before `take` so the gather stays in-bounds

## Test plan
- [x] `test_diag_1d_to_2d_negative_k` now passes (was failing with `NCC_EVRF056` OOB error)
- [x] All other diag tests (`test_diag_1d_to_2d`, `test_diag_2d_to_1d`, `test_diagonal_gather`) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)