### PR TITLE
fix: migrate example NKI kernels to beta3 and fix relative build dir

### DIFF
--- a/examples/models/qwen3/kernels/sampling.py
+++ b/examples/models/qwen3/kernels/sampling.py
@@ -30,7 +30,7 @@ def stream_shuffle_broadcast(src, dst):
         )
 
 
-@nki.jit(platform_target="trn2")
+@nki.jit
 def nki_rmsnorm_kernel(input_tensor, weight, eps):
     """
     RMSNorm NKI kernel - based on AWS official tutorial pattern.

--- a/examples/playground/simple_nki_kernel.py
+++ b/examples/playground/simple_nki_kernel.py
@@ -1,31 +1,30 @@
 #!/usr/bin/env python3
 """
-Simple NKI Beta2 Kernel Example using DeviceKernel and DeviceTensor
+Simple NKI Beta3 Kernel Example using DeviceKernel and DeviceTensor
 """
 
 import time
 
 import nki
-import nki.isa as nisa
 import nki.language as nl
 import numpy as np
 from nkipy.core import nki_op  # noqa: F401, make sure monkey patch is applied
 from nkipy.runtime import DeviceKernel, DeviceTensor
 
 
-@nki.jit(platform_target="trn2")
+@nki.jit
 def nki_tensor_add(a_input, b_input):
-    a_tile = sbuf.view(dtype=a_input.dtype, shape=a_input.shape)  # noqa: F821
-    nisa.dma_copy(dst=a_tile, src=a_input)
+    # Beta 3 frontend: index the inputs with affine ranges, load into SBUF,
+    # compute, then store the result into a fresh HBM output tensor.
+    ix = nl.affine_range(a_input.shape[0])
+    iy = nl.affine_range(a_input.shape[1])
 
-    b_tile = sbuf.view(dtype=b_input.dtype, shape=b_input.shape)  # noqa: F821
-    nisa.dma_copy(dst=b_tile, src=b_input)
+    a_tile = nl.load(a_input[ix, iy])
+    b_tile = nl.load(b_input[ix, iy])
+    c_tile = nl.add(a_tile, b_tile)
 
-    c_tile = sbuf.view(dtype=a_input.dtype, shape=a_input.shape)  # noqa: F821
-    nisa.tensor_tensor(dst=c_tile, data1=a_tile, data2=b_tile, op=nl.add)
-
-    c_output = hbm.view(dtype=a_input.dtype, shape=a_input.shape)  # noqa: F821
-    nisa.dma_copy(dst=c_output, src=c_tile)
+    c_output = nl.ndarray(a_input.shape, dtype=a_input.dtype, buffer=nl.shared_hbm)
+    nl.store(c_output[ix, iy], value=c_tile)
 
     return c_output
 

--- a/nkipy/src/nkipy/core/compile.py
+++ b/nkipy/src/nkipy/core/compile.py
@@ -163,6 +163,10 @@ class Compiler:
         use_neuronx_cc_python_interface: bool = False,
     ) -> Path:
         """Compile an HLOModule to NEFF via neuronx-cc."""
+        # Resolve to an absolute path: the compile below chdirs into work_dir,
+        # so a relative work_dir (e.g. "./build/...") would otherwise get
+        # doubled ("build/.../build/...") in the neuronx-cc input path.
+        work_dir = work_dir.resolve()
         hlo_pb_path = work_dir / "hlo_module.pb"
         proto = ir.to_proto()
         with open(hlo_pb_path, "wb") as f:


### PR DESCRIPTION
## Summary

Verifying the examples on the current NKI **beta3** frontend (`nki` 0.4.0) surfaced three breakages:

- **`nki.jit(platform_target="trn2")` is now a hard error in beta3.** Dropped the kwarg from the qwen3 rmsnorm kernel (`examples/models/qwen3/kernels/sampling.py`) and the `simple_nki_kernel.py` playground example. The platform target is auto-detected at compile time (or set via `NEURON_PLATFORM_TARGET_OVERRIDE`).

- **`simple_nki_kernel.py` used the beta2 tile API** (`sbuf.view` / `hbm.view` / `nisa.*`), which no longer resolves in beta3. Rewrote it with the beta3 `nl` API (`affine_range` / `load` / `add` / `ndarray` / `store`), matching the pattern in `tests/unit/test_nki.py::test_nki_direct_jit_beta3`.

- **Relative `build_dir` produced a doubled compile path.** `compile._compile_hlo` chdirs into `work_dir` but passed the *relative* `work_dir/hlo_module.pb`, so a relative `build_dir` (qwen3 uses `"./build"`) got doubled (`build/.../build/.../hlo_module.pb`) and `neuronx-cc` failed with `Input file not found`. Fixed by resolving `work_dir` to an absolute path first.

## Test plan

Verified end-to-end on trn2:
- `examples/playground/simple_nki_kernel.py` — output matches NumPy exactly (max rel error 0.0).
- `examples/models/qwen3/` (Qwen3-30B-A3B, TP4) — generates coherently ("The capital of France is Paris…") at ~54 tok/s.
- `tests/unit/test_nki.py` beta3/simple tests (8 passed, 1 skipped) and `test_compile_wrappers.py` (10 passed) still pass with the `compile.py` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)