### PR TITLE
fix: correct knob annotate() mem_space values and TileOp emission

### DIFF
--- a/nkigen/nkigen/builder.py
+++ b/nkigen/nkigen/builder.py
@@ -1605,7 +1605,7 @@ def annotate(
 
     ms_attr = None
     if mem_space is not None:
-        ms_map = {"Hbm": 0, "Psum": 1, "Sbuf": 2, "SharedHbm": 3}
+        ms_map = {"Hbm": 1, "Psum": 2, "Sbuf": 3, "SharedHbm": 4}
         ms_attr = ir.IntegerAttr.get(ir.IntegerType.get_signless(32), ms_map[mem_space])
 
     pd_attr = None
@@ -1616,9 +1616,14 @@ def annotate(
     if tile_size is not None:
         ts_attr = ir.DenseI64ArrayAttr.get(tile_size)
 
-    rt_attr = None
-    if reduction_tile is not None:
-        rt_attr = ir.DenseI64ArrayAttr.get(reduction_tile)
+    # loop_tile_size carries one entry per linalg iterator, in
+    # [parallel..., reduction...] order. Concatenate whichever parts are
+    # present so reduction_tile is never silently dropped (e.g. a full
+    # reduction has only reduction iterators, no parallel tile_size).
+    loop_tile_attr = None
+    if tile_size is not None or reduction_tile is not None:
+        loop_tile = list(tile_size or []) + list(reduction_tile or [])
+        loop_tile_attr = ir.DenseI64ArrayAttr.get(loop_tile)
 
     if ms_attr is not None or pd_attr is not None or ts_attr is not None:
         nkipy_d.LayoutOp(
@@ -1629,11 +1634,10 @@ def annotate(
             loc=loc,
         )
 
-    if ts_attr is not None or rt_attr is not None:
+    if loop_tile_attr is not None:
         nkipy_d.TileOp(
             target=value,
-            loop_tile_size=ts_attr,
-            reduction_tile=rt_attr,
+            loop_tile_size=loop_tile_attr,
             loc=loc,
         )
     return x


### PR DESCRIPTION
## Summary

Fixes two issues in nkigen's `builder.annotate()` that caused the repo-root nkigen test suites to error out. Both are pure-Python changes to `nkigen/nkigen/builder.py`.

- **mem_space enum values.** `ms_map` used 0-based values (`Hbm=0 … SharedHbm=3`), but the C++ dialect in `NkipyAttrs.td` defines them 1-based (`Hbm=1, Psum=2, Sbuf=3, SharedHbm=4`). Value `0` is explicitly disallowed there — a zero-valued attribute is dropped during MLIR uniquing, which would make memory-space annotations silent no-ops. Corrected to match the dialect.
- **`TileOp` emission.** `annotate()` passed a `reduction_tile` keyword to `TileOp`, but the generated `TileOp` binding only accepts `loop_tile_size` (`TypeError: TileOp.__init__() got an unexpected keyword argument 'reduction_tile'`). Merge `tile_size` and `reduction_tile` into a single `loop_tile_size` array.

This supersedes #60, which was branched off `pr-58` rather than `main`; #60 will be closed.

## Test plan

Ran on a Trainium box (64 Neuron cores, on-device execution) with nkigen installed editable against a local LLVM/MLIR SDK:

- `tests/test_nkigen_ops.py tests/test_nkigen_numerical.py tests/unit/test_nkigen_backend.py` — **45 passed, 8 xfailed** (previously 5 failed with the `reduction_tile` TypeError).
- `nkigen/tests/passes` + `nkigen/tests/unit` — 250 passed.
- `nkigen/tests/e2e` — 62 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)