### PR TITLE
Support Neuron SDK 2.31 on Python 3.12

### DIFF
--- a/nkipy/pyproject.toml
+++ b/nkipy/pyproject.toml
@@ -17,7 +17,12 @@ version = "0.1.0"
 description = "A lightweight Pythonic kernel environment for AWS Neuron"
 requires-python = ">=3.10"
 authors = [{ name = "NKIPy Team (Ziyang Xu et al.)" }]
-dependencies = ["numpy>=1.26", "neuronx-cc>=0.0,!=1.*,<3.0", "nki>=0.1.0"]
+dependencies = [
+    "numpy>=1.26",
+    "neuronx-cc>=0.0,!=1.*,<3.0",
+    "nki>=0.1.0",
+    "protobuf>=7.35.0",
+]
 
 [tool.uv.sources]
 neuronx-cc = { index = "neuron" }

--- a/tests/unit/test_nki.py
+++ b/tests/unit/test_nki.py
@@ -412,15 +412,13 @@ def test_nki_direct_jit_beta3():
 
     @nki_beta3.jit
     def nki_add_kernel(a_input, b_input):
-        ix = nl_beta3.affine_range(128)
-        iy = nl_beta3.affine_range(512)
-        a_tile = nl_beta3.load(a_input[ix, iy])
-        b_tile = nl_beta3.load(b_input[ix, iy])
+        a_tile = nl_beta3.load(a_input[:, :])
+        b_tile = nl_beta3.load(b_input[:, :])
         c_tile = nl_beta3.add(a_tile, b_tile)
         output = nl_beta3.ndarray(
             a_input.shape, dtype=a_input.dtype, buffer=nl_beta3.shared_hbm
         )
-        nl_beta3.store(output[ix, iy], value=c_tile)
+        nl_beta3.store(output[:, :], value=c_tile)
         return output
 
     a = np.random.rand(128, 512).astype(np.float32)
@@ -441,15 +439,13 @@ def test_nki_direct_jit_beta3_called_twice_different_shapes():
 
     @nki_beta3.jit
     def nki_add_kernel(a_input, b_input):
-        ix = nl_beta3.affine_range(128)
-        iy = nl_beta3.affine_range(512)
-        a_tile = nl_beta3.load(a_input[ix, iy])
-        b_tile = nl_beta3.load(b_input[ix, iy])
+        a_tile = nl_beta3.load(a_input[:, :])
+        b_tile = nl_beta3.load(b_input[:, :])
         c_tile = nl_beta3.add(a_tile, b_tile)
         output = nl_beta3.ndarray(
             a_input.shape, dtype=a_input.dtype, buffer=nl_beta3.shared_hbm
         )
-        nl_beta3.store(output[ix, iy], value=c_tile)
+        nl_beta3.store(output[:, :], value=c_tile)
         return output
 
     a1 = np.random.rand(128, 512).astype(np.float32)
@@ -474,15 +470,13 @@ def test_nki_direct_jit_beta3_kwargs_operand_order():
 
     @nki_beta3.jit
     def nki_add_kernel(a_input, b_input):
-        ix = nl_beta3.affine_range(128)
-        iy = nl_beta3.affine_range(512)
-        a_tile = nl_beta3.load(a_input[ix, iy])
-        b_tile = nl_beta3.load(b_input[ix, iy])
+        a_tile = nl_beta3.load(a_input[:, :])
+        b_tile = nl_beta3.load(b_input[:, :])
         c_tile = nl_beta3.add(a_tile, b_tile)
         output = nl_beta3.ndarray(
             a_input.shape, dtype=a_input.dtype, buffer=nl_beta3.shared_hbm
         )
-        nl_beta3.store(output[ix, iy], value=c_tile)
+        nl_beta3.store(output[:, :], value=c_tile)
         return output
 
     a = np.random.rand(128, 512).astype(np.float32)
@@ -503,15 +497,13 @@ def test_nki_wrap_kernel_beta3():
 
     @nki_beta3.jit
     def nki_add_kernel(a_input, b_input):
-        ix = nl_beta3.affine_range(128)
-        iy = nl_beta3.affine_range(512)
-        a_tile = nl_beta3.load(a_input[ix, iy])
-        b_tile = nl_beta3.load(b_input[ix, iy])
+        a_tile = nl_beta3.load(a_input[:, :])
+        b_tile = nl_beta3.load(b_input[:, :])
         c_tile = nl_beta3.add(a_tile, b_tile)
         output = nl_beta3.ndarray(
             a_input.shape, dtype=a_input.dtype, buffer=nl_beta3.shared_hbm
         )
-        nl_beta3.store(output[ix, iy], value=c_tile)
+        nl_beta3.store(output[:, :], value=c_tile)
         return output
 
     a = np.random.rand(128, 512).astype(np.float32)
@@ -539,12 +531,10 @@ def test_nki_mutable_tensor_beta3():
 
     @nki_beta3.jit
     def nki_inplace_add_kernel(a_input, b_input):
-        ix = nl_beta3.affine_range(128)
-        iy = nl_beta3.affine_range(512)
-        a_tile = nl_beta3.load(a_input[ix, iy])
-        b_tile = nl_beta3.load(b_input[ix, iy])
+        a_tile = nl_beta3.load(a_input[:, :])
+        b_tile = nl_beta3.load(b_input[:, :])
         c_tile = nl_beta3.add(a_tile, b_tile)
-        nl_beta3.store(a_input[ix, iy], value=c_tile)
+        nl_beta3.store(a_input[:, :], value=c_tile)
         return a_input
 
     a = np.random.rand(128, 512).astype(np.float32)
@@ -577,12 +567,10 @@ def test_nki_mutable_tensor_beta3_hardware():
 
     @nki_beta3.jit
     def nki_inplace_add_kernel(a_input, b_input):
-        ix = nl_beta3.affine_range(128)
-        iy = nl_beta3.affine_range(512)
-        a_tile = nl_beta3.load(a_input[ix, iy])
-        b_tile = nl_beta3.load(b_input[ix, iy])
+        a_tile = nl_beta3.load(a_input[:, :])
+        b_tile = nl_beta3.load(b_input[:, :])
         c_tile = nl_beta3.add(a_tile, b_tile)
-        nl_beta3.store(a_input[ix, iy], value=c_tile)
+        nl_beta3.store(a_input[:, :], value=c_tile)
         return a_input
 
     a = np.random.rand(128, 512).astype(np.float32)
@@ -621,15 +609,13 @@ def test_nki_simple_beta3_hardware():
 
     @nki_beta3.jit
     def nki_add_kernel(a_input, b_input):
-        ix = nl_beta3.affine_range(128)
-        iy = nl_beta3.affine_range(512)
-        a_tile = nl_beta3.load(a_input[ix, iy])
-        b_tile = nl_beta3.load(b_input[ix, iy])
+        a_tile = nl_beta3.load(a_input[:, :])
+        b_tile = nl_beta3.load(b_input[:, :])
         c_tile = nl_beta3.add(a_tile, b_tile)
         output = nl_beta3.ndarray(
             a_input.shape, dtype=a_input.dtype, buffer=nl_beta3.shared_hbm
         )
-        nl_beta3.store(output[ix, iy], value=c_tile)
+        nl_beta3.store(output[:, :], value=c_tile)
         return output
 
     a = np.random.rand(128, 512).astype(np.float32)

--- a/tests/unit/test_nkigen_backend.py
+++ b/tests/unit/test_nkigen_backend.py
@@ -50,6 +50,7 @@ class TestKnobDispatch:
 
 def _make_silu_kernel_builder(M, N, tile_p=128, tile_f=128):
     """Return a real NKI kernel_builder function that computes SiLU activation."""
+
     def silu_kernel(input_0, output_0):
         import nki.compiler.kernel_builder as nb
         import nki.language as nl
@@ -88,6 +89,7 @@ def _make_silu_kernel_builder(M, N, tile_p=128, tile_f=128):
                     ],
                     src=out_sbuf,
                 )
+
     return silu_kernel
 
 
@@ -147,7 +149,7 @@ class TestNkiGenTraceContext:
     @pytest.fixture(autouse=True)
     def _skip_if_no_nkigen(self):
         try:
-            import nkigen  # noqa: F401
+            import nkigen.builder  # noqa: F401
         except ImportError:
             pytest.skip("nkigen not installed")
 
@@ -171,13 +173,14 @@ class TestSpecializeNkigen:
     @pytest.fixture(autouse=True)
     def _skip_if_no_nkigen(self):
         try:
-            import nkigen  # noqa: F401
+            import nkigen.builder  # noqa: F401
         except ImportError:
             pytest.skip("nkigen not installed")
 
     @staticmethod
     def _run(func, *np_args):
         from utils import NEURON_AVAILABLE, on_device_test, trace_and_compile
+
         if NEURON_AVAILABLE:
             return on_device_test(func, "nkigen", *np_args)
         else:
@@ -231,7 +234,7 @@ class TestSpecializeNkigen:
 
     @pytest.mark.xfail(
         reason="custom_op kernel_builder tracing requires TracedArray, "
-               "not yet wired through NKIPyTensorRef path"
+        "not yet wired through NKIPyTensorRef path"
     )
     def test_custom_op_with_kernel_builder(self):
         """nki_custom_op with real kernel_builder traces through nkigen backend."""
@@ -263,7 +266,7 @@ class TestNkigenInplaceUpdate:
     @pytest.fixture(autouse=True)
     def _skip_if_no_nkigen(self):
         try:
-            import nkigen  # noqa: F401
+            import nkigen.builder  # noqa: F401
         except ImportError:
             pytest.skip("nkigen not installed")
 
@@ -420,5 +423,3 @@ class TestNkigenInplaceUpdate:
         ir, result = self._trace_and_run(kernel, a, b)
         if result is not None:
             baremetal_assert_allclose(result, expected)
-
-


### PR DESCRIPTION
Description:

  ## Summary

  Update NKIPy compatibility for Neuron SDK 2.31 and its NKI 0.5 frontend when running on Python 3.12.

  - Require the protobuf runtime version needed by the generated XLA protobuf modules.
  - Update Beta3 test kernels to use supported full-tensor indexing instead of `affine_range` values as tensor indices.
  - Detect the actual `nkigen.builder` package when deciding whether NKIGen tests are available.

  This does not narrow NKIPy's existing `requires-python >=3.10` declaration.

  ## Testing

  - `7 passed, 11 deselected` for the targeted Beta3 NKI tests.
  - `8 passed, 12 skipped` for the NKIGen backend tests.
  - Full combined NKIPy validation: `757 passed, 42 skipped, 4 xfailed`.
