### PR TITLE
Make Spike runtime shutdown safe on Python 3.12

### DIFF
--- a/spike/src/include/model.h
+++ b/spike/src/include/model.h
@@ -2,6 +2,8 @@
 #define SPIKE_SRC_INCLUDE_MODEL_H
 
 #include "tensor_set.h"
+#include <atomic>
+#include <memory>
 #include <optional>
 
 namespace spike {
@@ -33,7 +35,7 @@ public:
   uint32_t get_world_size() const { return world_size_; }
   bool get_is_collective() const { return is_collective_; }
   bool is_unloaded() const;
-  bool is_owner() const { return spike_ != nullptr; }
+  bool is_owner() const { return runtime_closed_ != nullptr; }
 
   // String representation
   std::string to_string() const;
@@ -51,7 +53,7 @@ private:
   uint32_t rank_id_;
   uint32_t world_size_;
   bool is_collective_;
-  const Spike *spike_;
+  std::shared_ptr<std::atomic_bool> runtime_closed_;
 };
 
 } // namespace spike

--- a/spike/src/include/spike.h
+++ b/spike/src/include/spike.h
@@ -4,6 +4,7 @@
 #include "model.h"
 #include "nrt_wrapper.h"
 #include "tensor.h"
+#include <atomic>
 #include <memory>
 #include <optional>
 #include <unordered_map>
@@ -42,6 +43,9 @@ public:
   // Runtime management
   int close();
   bool is_closed() const { return runtime_.get() == nullptr; }
+  std::shared_ptr<std::atomic_bool> get_runtime_closed_state() const {
+    return runtime_closed_;
+  }
 
   // Model operations
   NrtModel load_model(const std::string &neff_file, uint32_t core_id = 0,
@@ -78,6 +82,7 @@ public:
 private:
   int verbose_level_;
   std::unique_ptr<NrtRuntime> runtime_;
+  std::shared_ptr<std::atomic_bool> runtime_closed_;
 
   // Helper methods
   NrtTensorSet create_tensor_sets(

--- a/spike/src/include/tensor.h
+++ b/spike/src/include/tensor.h
@@ -3,7 +3,9 @@
 
 #include "nrt_wrapper.h"
 
+#include <atomic>
 #include <cstdint>
+#include <memory>
 #include <string>
 
 namespace spike {
@@ -29,7 +31,7 @@ public:
     return ptr_ ? reinterpret_cast<uintptr_t>(nrt_tensor_get_va(ptr_)) : 0;
   }
   bool is_freed() const;
-  bool is_owner() const { return spike_ != nullptr; }
+  bool is_owner() const { return runtime_closed_ != nullptr; }
 
   // String representation
   std::string to_string() const;
@@ -49,7 +51,7 @@ private:
   uint32_t core_id_;
   uint64_t size_;
   std::string name_;
-  const Spike *spike_;
+  std::shared_ptr<std::atomic_bool> runtime_closed_;
 };
 
 } // namespace spike

--- a/spike/src/model.cpp
+++ b/spike/src/model.cpp
@@ -12,7 +12,7 @@ NrtModel::NrtModel(const std::string &neff_path, uint32_t core_id,
                    const Spike *spike)
     : ptr_(nullptr), neff_path_(neff_path), core_id_(core_id),
       rank_id_(rank_id), world_size_(world_size), is_collective_(cc_enabled),
-      spike_(spike) {
+      runtime_closed_(spike->get_runtime_closed_state()) {
 
   // Read NEFF file
   std::ifstream file(neff_path, std::ios::binary | std::ios::ate);
@@ -56,7 +56,7 @@ NrtModel::NrtModel(const std::string &neff_path, uint32_t core_id,
 NrtModel::NrtModel(nrt_model_t *ptr, uint32_t core_id, bool cc_enabled,
                    uint32_t rank_id, uint32_t world_size)
     : ptr_(ptr), core_id_(core_id), rank_id_(rank_id), world_size_(world_size),
-      is_collective_(cc_enabled), spike_(nullptr) {}
+      is_collective_(cc_enabled), runtime_closed_(nullptr) {}
 
 NrtModel::~NrtModel() { unload(); }
 
@@ -64,7 +64,7 @@ NrtModel::NrtModel(NrtModel &&other) noexcept
     : ptr_(other.ptr_), neff_path_(std::move(other.neff_path_)),
       core_id_(other.core_id_), rank_id_(other.rank_id_),
       world_size_(other.world_size_), is_collective_(other.is_collective_),
-      spike_(other.spike_) {
+      runtime_closed_(std::move(other.runtime_closed_)) {
   other.ptr_ = nullptr;
 }
 
@@ -77,14 +77,14 @@ NrtModel &NrtModel::operator=(NrtModel &&other) noexcept {
     rank_id_ = other.rank_id_;
     world_size_ = other.world_size_;
     is_collective_ = other.is_collective_;
-    spike_ = other.spike_;
+    runtime_closed_ = std::move(other.runtime_closed_);
     other.ptr_ = nullptr;
   }
   return *this;
 }
 
 bool NrtModel::is_unloaded() const {
-  return ptr_ == nullptr || (is_owner() && spike_->is_closed());
+  return ptr_ == nullptr || (is_owner() && runtime_closed_->load());
 }
 
 void NrtModel::execute(const NrtTensorSet &inputs, NrtTensorSet &outputs,

--- a/spike/src/python_bindings.cpp
+++ b/spike/src/python_bindings.cpp
@@ -97,7 +97,7 @@ NB_MODULE(_spike, m) {
                    "Is collective model")
       .def("__repr__", &NrtModel::to_string);
 
-  // Spike class - uses keep_alive for safe shared ownership with tensors/models
+  // Models and tensors share Spike's runtime-closed state in C++.
   nb::class_<Spike>(m, "Spike")
       .def(nb::init<int>(), "verbose_level"_a = 0,
            "Initialize Spike with verbose level")
@@ -110,10 +110,9 @@ NB_MODULE(_spike, m) {
       // Core runtime methods
       .def("close", &Spike::close, "Close the NRT runtime")
 
-      // Keep Spike alive for models that depend on it
       .def("load_model", &Spike::load_model, "neff_file"_a, "core_id"_a = 0,
            "cc_enabled"_a = false, "rank_id"_a = 0, "world_size"_a = 1,
-           nb::keep_alive<0, 1>(), "Load a model from NEFF file")
+           "Load a model from NEFF file")
 
       .def("unload_model", &Spike::unload_model, "model"_a, "Unload a model")
 
@@ -125,14 +124,13 @@ NB_MODULE(_spike, m) {
                                                      // to execute (enable CC)
            "Execute a model with given inputs and outputs")
 
-      // Keep Spike alive for tensors that depend on it
       .def("allocate_tensor", &Spike::allocate_tensor, "size"_a,
            "core_id"_a = 0, nb::arg("name") = nb::none(),
-           nb::keep_alive<0, 1>(), "Allocate a tensor on device")
+           "Allocate a tensor on device")
 
       .def("slice_from_tensor", &Spike::slice_from_tensor, "source"_a,
            "offset"_a = 0, "size"_a = 0, nb::arg("name") = nb::none(),
-           nb::keep_alive<0, 1>(), "Create a tensor slice from another tensor")
+           "Create a tensor slice from another tensor")
 
       .def("free_tensor", &Spike::free_tensor, "tensor"_a, "Free a tensor")
 

--- a/spike/src/spike.cpp
+++ b/spike/src/spike.cpp
@@ -7,7 +7,8 @@ namespace spike {
 static bool g_alive_spike_instance_exists = false;
 
 Spike::Spike(int verbose_level)
-    : verbose_level_(verbose_level), runtime_(nullptr) {
+    : verbose_level_(verbose_level), runtime_(nullptr),
+      runtime_closed_(std::make_shared<std::atomic_bool>(false)) {
   if (g_alive_spike_instance_exists) {
     throw SpikeError(
         "Cannot create Spike instance: a previous instance still exists. "
@@ -35,6 +36,7 @@ uint32_t Spike::get_visible_neuron_core_count() {
 }
 
 int Spike::close() {
+  runtime_closed_->store(true);
   runtime_.reset();
   g_alive_spike_instance_exists = false;
   return 0;

--- a/spike/src/spike/spike_singleton.py
+++ b/spike/src/spike/spike_singleton.py
@@ -150,10 +150,14 @@ def get_spike_singleton() -> _Spike:
 def _cleanup() -> None:
     """Cleanup function called at program exit."""
     global _runtime
-    # Note: Spike object from nanobind is RAII and Python GC managed, so no need
-    # to call `.close()` explicitly. However, we do want to set the global to
-    # None to make sure it does before nanobind ref leak check.
-    _runtime = None
+    with _lock:
+        runtime = _runtime
+        _runtime = None
+    if runtime is not None:
+        # Close NRT before Python starts tearing down nanobind module state.
+        # Models and tensors retain a shared closed-state token and skip NRT
+        # cleanup when their own destructors run later.
+        runtime.close()
 
 
 atexit.register(_cleanup)

--- a/spike/src/tensor.cpp
+++ b/spike/src/tensor.cpp
@@ -9,7 +9,7 @@ namespace spike {
 NrtTensor::NrtTensor(nrt_tensor_placement_t placement, uint32_t core_id,
                      size_t size, const std::string &name, const Spike *spike)
     : ptr_(nullptr), core_id_(core_id), size_(size), name_(name),
-      spike_(spike) {
+      runtime_closed_(spike->get_runtime_closed_state()) {
 
   NRT_STATUS status =
       nrt_tensor_allocate(placement, core_id, size, name.c_str(), &ptr_);
@@ -22,7 +22,7 @@ NrtTensor::NrtTensor(nrt_tensor_placement_t placement, uint32_t core_id,
 NrtTensor::NrtTensor(const NrtTensor &source, size_t offset, size_t size,
                      const std::string &name)
     : ptr_(nullptr), core_id_(source.core_id_), size_(size), name_(name),
-      spike_(source.spike_) {
+      runtime_closed_(source.runtime_closed_) {
   if (source.is_freed()) {
     throw SpikeError(
         "Unable to allocate tensor slice from a source tensor that is freed. "
@@ -41,7 +41,8 @@ NrtTensor::~NrtTensor() { free(); }
 
 NrtTensor::NrtTensor(NrtTensor &&other) noexcept
     : ptr_(other.ptr_), core_id_(other.core_id_), size_(other.size_),
-      name_(std::move(other.name_)), spike_(other.spike_) {
+      name_(std::move(other.name_)),
+      runtime_closed_(std::move(other.runtime_closed_)) {
   other.ptr_ = nullptr;
 }
 
@@ -52,14 +53,14 @@ NrtTensor &NrtTensor::operator=(NrtTensor &&other) noexcept {
     core_id_ = other.core_id_;
     name_ = std::move(other.name_);
     size_ = other.size_;
-    spike_ = other.spike_;
+    runtime_closed_ = std::move(other.runtime_closed_);
     other.ptr_ = nullptr;
   }
   return *this;
 }
 
 bool NrtTensor::is_freed() const {
-  return ptr_ == nullptr || (is_owner() && spike_->is_closed());
+  return ptr_ == nullptr || (is_owner() && runtime_closed_->load());
 }
 
 void NrtTensor::write(const void *data, size_t size, size_t offset) {

--- a/tests/unit/test_spike_cpp_api.py
+++ b/tests/unit/test_spike_cpp_api.py
@@ -1,6 +1,8 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 import os
+import subprocess
+import sys
 import time
 
 import numpy as np
@@ -155,20 +157,43 @@ def test_tensor_lifecycle_on_delete():
     """Test tensor lifecycle when Spike instance and tensor are deleted.
 
     This test verifies that deleting a Spike instance and its allocated tensor
-    works correctly without errors. Uses keep_alive to ensure proper cleanup order.
+    works correctly without errors after the runtime has already closed.
 
     Runs before shared_spike_instance is created.
     """
     try:
         s = Spike()
         t = s.allocate_tensor(100)
-        del s  # Spike ref removed, but tensor keeps it alive via keep_alive
-        del t  # Now Spike can be destroyed
+        del s
+        del t
     except Exception as e:
         pytest.fail(f"tensor_lifecycle_on_delete failed: {e}")
 
 
 @pytest.mark.order(2)
+def test_interpreter_shutdown_with_live_tensors():
+    """Interpreter finalization must not traverse stale nanobind weakrefs."""
+    script = """
+from spike import get_spike_singleton
+
+runtime = get_spike_singleton()
+tensors = [runtime.allocate_tensor(4) for _ in range(128)]
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"child exited with {result.returncode}\n"
+        f"stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )
+
+
+@pytest.mark.order(3)
 def test_core_initialization():
     """Test core initialization and cleanup - runs BEFORE shared_spike fixture is created
 
@@ -196,7 +221,7 @@ def test_core_initialization():
 
 
 # This test will run third - it has order=3
-@pytest.mark.order(3)
+@pytest.mark.order(4)
 def test_static_methods():
     """Test static methods"""
     try:


### PR DESCRIPTION
Description:

  ## Summary

  Fix a Python 3.12 interpreter-finalization crash caused by nanobind `keep_alive` weakrefs between Spike and its model and tensor wrappers.

  - Replace wrapper references to the owning `Spike` object with a shared runtime-closed state.
  - Remove nanobind `keep_alive` policies from model and tensor creation.
  - Close the singleton runtime explicitly during `atexit`, before nanobind module teardown.
  - Make model and tensor destructors skip NRT cleanup after the runtime has closed.
  - Add a subprocess regression test that exits with live tensor wrappers.

  The change preserves Spike's single-runtime ownership model without retaining Python weakref relationships during interpreter shutdown.

  ## Testing

  - `3 passed, 6 deselected` for targeted lifecycle and finalization tests.
  - `4 passed` for the standalone Spike core API tests.
  - `21 passed` for the broader Spike lifecycle suite.
  - Full combined NKIPy validation: `757 passed, 42 skipped, 4 xfailed`.