### PR TITLE
fix(hlo): normalize static slice bounds

### DIFF
--- a/nkipy/src/nkipy/core/tensor.py
+++ b/nkipy/src/nkipy/core/tensor.py
@@ -689,18 +689,21 @@ class NKIPyTensorRef(TensorArithmeticMixin, TensorOperationMixin):
         limit_indices = []
         strides = []
         squeeze_dims = []  # Dimensions to squeeze (from integer indexing)
+        reverse_dims = []
 
         for dim, idx in enumerate(indices):
             if isinstance(idx, slice):
-                start = idx.start if idx.start is not None else 0
-                stop = idx.stop if idx.stop is not None else self.shape[dim]
-                step = idx.step if idx.step is not None else 1
+                dim_size = self.shape[dim]
+                start, stop, step = idx.indices(dim_size)
 
-                # Normalize negative indices
-                if start < 0:
-                    start = self.shape[dim] + start
-                if stop < 0:
-                    stop = self.shape[dim] + stop
+                if (step > 0 and start >= stop) or (step < 0 and start <= stop):
+                    start, stop, step = 0, 0, 1
+                elif step < 0:
+                    # HLO slices require positive strides; reverse and remap bounds.
+                    reverse_dims.append(dim)
+                    start = dim_size - 1 - start
+                    stop = dim_size - 1 - stop
+                    step = -step
 
                 start_indices.append(start)
                 limit_indices.append(stop)
@@ -718,8 +721,13 @@ class NKIPyTensorRef(TensorArithmeticMixin, TensorOperationMixin):
                     f"Unsupported index type in static slicing: {type(idx)}"
                 )
 
+        result = self
+        for dim in reverse_dims:
+            reversed_indices = np.arange(self.shape[dim] - 1, -1, -1, dtype=np.int32)
+            result = nkipy_ops.take(result, reversed_indices, axis=dim)
+
         return nkipy_ops.static_slice(
-            self, start_indices, limit_indices, strides, squeeze_dims
+            result, start_indices, limit_indices, strides, squeeze_dims
         )
 
     def _do_scatter_indexing(self, indices, value):

--- a/tests/unit/test_indexing_slicing_comprehensive.py
+++ b/tests/unit/test_indexing_slicing_comprehensive.py
@@ -656,12 +656,12 @@ class TestIndexingSlicingAdvanced:
 
         a = sample_tensors["small_1d"]
         expected = kernel(a)
-        _assert_traced_shape(kernel, trace_mode, expected.shape, a)
 
         if NEURON_AVAILABLE:
             out_baremetal = on_device_test(kernel, trace_mode, a)
             baremetal_assert_allclose(expected, out_baremetal)
         else:
+            _assert_traced_shape(kernel, trace_mode, expected.shape, a)
             trace_and_compile(kernel, trace_mode, a)
 
     def test_reverse_slice_with_step(self, trace_mode, sample_tensors):
@@ -670,12 +670,12 @@ class TestIndexingSlicingAdvanced:
 
         a = sample_tensors["small_1d"]
         expected = kernel(a)
-        _assert_traced_shape(kernel, trace_mode, expected.shape, a)
 
         if NEURON_AVAILABLE:
             out_baremetal = on_device_test(kernel, trace_mode, a)
             baremetal_assert_allclose(expected, out_baremetal)
         else:
+            _assert_traced_shape(kernel, trace_mode, expected.shape, a)
             trace_and_compile(kernel, trace_mode, a)
 
     @pytest.mark.parametrize("index", [slice(40, 50), slice(5, 3), slice(3, 5, -1)])
@@ -685,12 +685,12 @@ class TestIndexingSlicingAdvanced:
 
         a = sample_tensors["small_1d"]
         expected = kernel(a)
-        _assert_traced_shape(kernel, trace_mode, expected.shape, a)
 
         if NEURON_AVAILABLE:
             out_baremetal = on_device_test(kernel, trace_mode, a)
             baremetal_assert_allclose(expected, out_baremetal)
         else:
+            _assert_traced_shape(kernel, trace_mode, expected.shape, a)
             trace_and_compile(kernel, trace_mode, a)
 
     def test_multidimensional_reverse_slice(self, trace_mode, sample_tensors):
@@ -699,12 +699,12 @@ class TestIndexingSlicingAdvanced:
 
         a = sample_tensors["small_2d"]
         expected = kernel(a)
-        _assert_traced_shape(kernel, trace_mode, expected.shape, a)
 
         if NEURON_AVAILABLE:
             out_baremetal = on_device_test(kernel, trace_mode, a)
             baremetal_assert_allclose(expected, out_baremetal)
         else:
+            _assert_traced_shape(kernel, trace_mode, expected.shape, a)
             trace_and_compile(kernel, trace_mode, a)
 
     def test_step_slicing_assignment(self, trace_mode, sample_tensors):

--- a/tests/unit/test_indexing_slicing_comprehensive.py
+++ b/tests/unit/test_indexing_slicing_comprehensive.py
@@ -13,12 +13,18 @@ from typing import Dict
 
 import numpy as np
 import pytest
+from nkipy.core.trace import NKIPyKernel
 from utils import (
     NEURON_AVAILABLE,
     baremetal_assert_allclose,
     on_device_test,
     trace_and_compile,
 )
+
+
+def _assert_traced_shape(kernel, trace_mode, expected_shape, *args):
+    traced = NKIPyKernel.trace(kernel, backend=trace_mode).specialize(*args)
+    assert traced.outputs[0].shape == expected_shape
 
 
 class TestIndexingSlicingCore:
@@ -354,6 +360,7 @@ class TestIndexingSlicingAdvanced:
         """Create sample tensors for advanced testing"""
 
         return {
+            "small_1d": np.random.randn(32).astype(np.float32),
             "small_2d": np.random.randn(8, 16).astype(np.float32),
             "small_3d": np.random.randn(4, 8, 12).astype(np.float32),
             "batch_seq": np.random.randn(4, 32, 64).astype(np.float32),
@@ -636,6 +643,63 @@ class TestIndexingSlicingAdvanced:
 
         a = sample_tensors["small_2d"]
         expected = kernel(a)
+
+        if NEURON_AVAILABLE:
+            out_baremetal = on_device_test(kernel, trace_mode, a)
+            baremetal_assert_allclose(expected, out_baremetal)
+        else:
+            trace_and_compile(kernel, trace_mode, a)
+
+    def test_reverse_slice(self, trace_mode, sample_tensors):
+        def kernel(a):
+            return a[::-1]
+
+        a = sample_tensors["small_1d"]
+        expected = kernel(a)
+        _assert_traced_shape(kernel, trace_mode, expected.shape, a)
+
+        if NEURON_AVAILABLE:
+            out_baremetal = on_device_test(kernel, trace_mode, a)
+            baremetal_assert_allclose(expected, out_baremetal)
+        else:
+            trace_and_compile(kernel, trace_mode, a)
+
+    def test_reverse_slice_with_step(self, trace_mode, sample_tensors):
+        def kernel(a):
+            return a[40:3:-4]
+
+        a = sample_tensors["small_1d"]
+        expected = kernel(a)
+        _assert_traced_shape(kernel, trace_mode, expected.shape, a)
+
+        if NEURON_AVAILABLE:
+            out_baremetal = on_device_test(kernel, trace_mode, a)
+            baremetal_assert_allclose(expected, out_baremetal)
+        else:
+            trace_and_compile(kernel, trace_mode, a)
+
+    @pytest.mark.parametrize("index", [slice(40, 50), slice(5, 3), slice(3, 5, -1)])
+    def test_empty_slice(self, trace_mode, sample_tensors, index):
+        def kernel(a):
+            return a[index]
+
+        a = sample_tensors["small_1d"]
+        expected = kernel(a)
+        _assert_traced_shape(kernel, trace_mode, expected.shape, a)
+
+        if NEURON_AVAILABLE:
+            out_baremetal = on_device_test(kernel, trace_mode, a)
+            baremetal_assert_allclose(expected, out_baremetal)
+        else:
+            trace_and_compile(kernel, trace_mode, a)
+
+    def test_multidimensional_reverse_slice(self, trace_mode, sample_tensors):
+        def kernel(a):
+            return a[::-1, 14:2:-3]
+
+        a = sample_tensors["small_2d"]
+        expected = kernel(a)
+        _assert_traced_shape(kernel, trace_mode, expected.shape, a)
 
         if NEURON_AVAILABLE:
             out_baremetal = on_device_test(kernel, trace_mode, a)


### PR DESCRIPTION
## Summary

- normalize static slice bounds with Python's `slice.indices` so clipping and empty ranges match NumPy
- lower negative-step slices by reversing the relevant axes and emitting legal positive-stride HLO slices
- add regression coverage for full reversal, clipped stepped reversal, empty ranges, and multidimensional reversal

## Problem

Valid NumPy expressions such as `a[::-1]` and `a[10:20]` currently produce invalid HLO: reverse slicing can create a negative output extent and negative stride, while an out-of-range empty slice can retain illegal bounds and the wrong output shape.

## Testing

- `pytest -q tests/unit/test_indexing_slicing_comprehensive.py` (`53 passed, 1 skipped`)
- `pytest -q tests/unit/test_tensor_api.py -k "slice_extraction or test_flip"` (`5 passed`)
- compiled the original reverse and out-of-bounds reproducers with `neuronx-cc`
- checked the normalization formula across 168,960 slice combinations against Python semantics

I did not have Trainium hardware available, so validation covered HLO tracing and Neuron compilation rather than device execution. I also checked the general slice-shape contract separately with [TorchLean](https://github.com/lean-dojo/TorchLean); I can attach that formalization if it would be useful.