### PR TITLE
fix(indexing): preserve advanced-index axis order

### DIFF
--- a/nkipy/src/nkipy/core/tensor.py
+++ b/nkipy/src/nkipy/core/tensor.py
@@ -315,6 +315,65 @@ def _strip_newaxis(indices: tuple) -> tuple:
     return tuple(cleaned), newaxis_axes
 
 
+def _advanced_indices_are_separated(indices: tuple) -> bool:
+    """Whether basic indices separate scalar and array advanced indices."""
+    # NumPy treats integer scalars as part of the advanced block when an
+    # integer array index is also present.
+    advanced_positions = [
+        pos
+        for pos, idx in enumerate(indices)
+        if isinstance(idx, (int, NKIPyTensorRef, np.ndarray, list))
+    ]
+    if len(advanced_positions) < 2:
+        return False
+    return len(advanced_positions) != (
+        advanced_positions[-1] - advanced_positions[0] + 1
+    )
+
+
+def _advanced_index_output_layout(
+    indices: tuple,
+    dynamic_position: int,
+    index_ndim: int,
+    gather_axis: int,
+    result_ndim: int,
+    advanced_are_separated: bool,
+) -> tuple:
+    """Return the transpose order and newaxis positions for one advanced index."""
+    advanced_positions = {
+        pos
+        for pos, idx in enumerate(indices)
+        if pos == dynamic_position or isinstance(idx, int)
+    }
+
+    # Separated advanced dimensions move to the front; contiguous ones stay
+    # where the gather inserted them.
+    if advanced_are_separated:
+        permutation = (
+            list(range(gather_axis, gather_axis + index_ndim))
+            + list(range(gather_axis))
+            + list(range(gather_axis + index_ndim, result_ndim))
+        )
+        output_position = index_ndim
+    else:
+        permutation = list(range(result_ndim))
+        output_position = 0
+
+    newaxis_axes = []
+    advanced_inserted = False
+    for pos, idx in enumerate(indices):
+        if pos in advanced_positions:
+            if not advanced_are_separated and not advanced_inserted:
+                output_position += index_ndim
+                advanced_inserted = True
+            continue
+        if idx is None:
+            newaxis_axes.append(output_position)
+        output_position += 1
+
+    return permutation, newaxis_axes
+
+
 class NKIPyTensorRef(TensorArithmeticMixin, TensorOperationMixin):
     """
     NKIPy Tensor Reference
@@ -474,12 +533,15 @@ class NKIPyTensorRef(TensorArithmeticMixin, TensorOperationMixin):
             if not isinstance(indices, tuple):
                 indices = (indices,)
 
+            advanced_indices_are_separated = _advanced_indices_are_separated(indices)
             indices = _expand_ellipsis(indices, len(self.shape))
+            indices_with_newaxis = indices
             indices, newaxis_axes = _strip_newaxis(indices)
 
             # Pad with full slices if needed
             while len(indices) < len(self.shape):
                 indices = indices + (slice(None),)
+                indices_with_newaxis = indices_with_newaxis + (slice(None),)
 
             # Check if we have any tensor indices (dynamic indexing)
             # This includes NKIPyTensorRef, np.ndarray, and Python lists
@@ -548,29 +610,44 @@ class NKIPyTensorRef(TensorArithmeticMixin, TensorOperationMixin):
                     for i, idx in enumerate(static_indices)
                     if i != dynamic_index_dim
                 )
+                dims_removed_before = sum(
+                    1
+                    for idx in static_indices[:dynamic_index_dim]
+                    if isinstance(idx, int)
+                )
+                gather_axis = dynamic_index_dim - dims_removed_before
 
                 if has_static_slice:
                     # Apply static slicing first
                     sliced_tensor = self._do_static_slice(tuple(static_indices))
-                    # Now apply dynamic indexing on the sliced result
-                    # Need to adjust the dimension index after slicing
-                    # Count how many dimensions were removed before dynamic_index_dim
-                    dims_removed_before = sum(
-                        1
-                        for i, idx in enumerate(static_indices[:dynamic_index_dim])
-                        if isinstance(idx, int)
-                    )
-                    adjusted_dim = dynamic_index_dim - dims_removed_before
-
                     # Use np.take for dynamic indexing (dispatches to ops.take)
                     result = nkipy_ops.take(
-                        sliced_tensor, dynamic_index_value, axis=adjusted_dim
+                        sliced_tensor, dynamic_index_value, axis=gather_axis
                     )
                 else:
                     # No static slicing needed, just dynamic indexing
-                    result = nkipy_ops.take(
-                        self, dynamic_index_value, axis=dynamic_index_dim
-                    )
+                    result = nkipy_ops.take(self, dynamic_index_value, axis=gather_axis)
+
+                dynamic_position = next(
+                    pos
+                    for pos, idx in enumerate(indices_with_newaxis)
+                    if isinstance(idx, (NKIPyTensorRef, np.ndarray, list))
+                )
+                index_ndim = (
+                    dynamic_index_value.ndim
+                    if isinstance(dynamic_index_value, NKIPyTensorRef)
+                    else np.asarray(dynamic_index_value).ndim
+                )
+                permutation, newaxis_axes = _advanced_index_output_layout(
+                    indices_with_newaxis,
+                    dynamic_position,
+                    index_ndim,
+                    gather_axis,
+                    result.ndim,
+                    advanced_indices_are_separated,
+                )
+                if permutation != list(range(result.ndim)):
+                    result = nkipy_ops.transpose(result, axes=permutation)
             else:
                 # Pure static indexing
                 result = self._do_static_slice(indices)

--- a/tests/unit/test_indexing_slicing_comprehensive.py
+++ b/tests/unit/test_indexing_slicing_comprehensive.py
@@ -622,6 +622,98 @@ class TestIndexingSlicingAdvanced:
         else:
             trace_and_compile(kernel, trace_mode, a)
 
+    def test_separated_advanced_indexing(self, trace_mode, sample_tensors):
+        def kernel(a):
+            indices = np.array([0, 2, 4], dtype=np.int32)
+            return a[1, :, indices]
+
+        a = sample_tensors["small_3d"]
+        expected = kernel(a)
+
+        if NEURON_AVAILABLE:
+            out_baremetal = on_device_test(kernel, trace_mode, a)
+            baremetal_assert_allclose(expected, out_baremetal)
+        else:
+            _assert_traced_shape(kernel, trace_mode, expected.shape, a)
+            trace_and_compile(kernel, trace_mode, a)
+
+    def test_separated_advanced_indexing_dynamic(self, trace_mode, sample_tensors):
+        def kernel(a, indices):
+            return a[1, ::-1, indices]
+
+        a = sample_tensors["small_3d"]
+        indices = np.array([0, 2, 4], dtype=np.int32)
+        expected = kernel(a, indices)
+
+        if NEURON_AVAILABLE:
+            out_baremetal = on_device_test(kernel, trace_mode, a, indices)
+            baremetal_assert_allclose(expected, out_baremetal)
+        else:
+            _assert_traced_shape(kernel, trace_mode, expected.shape, a, indices)
+            trace_and_compile(kernel, trace_mode, a, indices)
+
+    def test_multidimensional_advanced_indexing(self, trace_mode, sample_tensors):
+        def kernel(a, indices):
+            return a[1, :, indices]
+
+        a = sample_tensors["small_3d"]
+        indices = np.array([[0], [2]], dtype=np.int32)
+        expected = kernel(a, indices)
+
+        if NEURON_AVAILABLE:
+            out_baremetal = on_device_test(kernel, trace_mode, a, indices)
+            baremetal_assert_allclose(expected, out_baremetal)
+        else:
+            _assert_traced_shape(kernel, trace_mode, expected.shape, a, indices)
+            trace_and_compile(kernel, trace_mode, a, indices)
+
+    def test_separated_advanced_indexing_with_newaxis(self, trace_mode, sample_tensors):
+        def kernel(a, indices):
+            return a[1, None, :, indices]
+
+        a = sample_tensors["small_3d"]
+        indices = np.array([0, 2], dtype=np.int32)
+        expected = kernel(a, indices)
+
+        if NEURON_AVAILABLE:
+            out_baremetal = on_device_test(kernel, trace_mode, a, indices)
+            baremetal_assert_allclose(expected, out_baremetal)
+        else:
+            _assert_traced_shape(kernel, trace_mode, expected.shape, a, indices)
+            trace_and_compile(kernel, trace_mode, a, indices)
+
+    def test_separated_advanced_indexing_with_empty_ellipsis(
+        self, trace_mode, sample_tensors
+    ):
+        def kernel(a, indices):
+            return a[:, 1, ..., indices]
+
+        a = sample_tensors["small_3d"]
+        indices = np.array([0, 2], dtype=np.int32)
+        expected = kernel(a, indices)
+
+        if NEURON_AVAILABLE:
+            out_baremetal = on_device_test(kernel, trace_mode, a, indices)
+            baremetal_assert_allclose(expected, out_baremetal)
+        else:
+            _assert_traced_shape(kernel, trace_mode, expected.shape, a, indices)
+            trace_and_compile(kernel, trace_mode, a, indices)
+
+    def test_contiguous_advanced_indexing_axis_order(self, trace_mode, sample_tensors):
+        def kernel(a, indices):
+            return a[:, 1, indices]
+
+        a = sample_tensors["small_3d"]
+        indices = np.array([0, 2], dtype=np.int32)
+        expected = kernel(a, indices)
+
+        if NEURON_AVAILABLE:
+            out_baremetal = on_device_test(kernel, trace_mode, a, indices)
+            baremetal_assert_allclose(expected, out_baremetal)
+        else:
+            _assert_traced_shape(kernel, trace_mode, expected.shape, a, indices)
+            trace_and_compile(kernel, trace_mode, a, indices)
+
     def test_step_slicing_with_offset(self, trace_mode, sample_tensors):
         def kernel(a):
             view = a[1::2, 2::3]


### PR DESCRIPTION
## Summary

- preserve NumPy axis ordering when scalar and array indices are separated by slices, `newaxis`, or ellipses
- move advanced-index dimensions to the front only for separated advanced indices while leaving contiguous layouts unchanged
- account for multidimensional index tensors and recompute `newaxis` positions after the permutation

## Problem

Mixed indexing currently produces compiler-valid HLO with silently transposed output axes:

```python
a = np.zeros((3, 4, 5), dtype=np.float32)
idx = np.array([0, 2], dtype=np.int32)

a[1, :, idx].shape  # NumPy: (2, 4), NKIPy traced: (4, 2)
```

NumPy treats integer scalars and integer arrays as one advanced-index block. When a basic index separates that block, the advanced dimensions move to the front. A zero-width ellipsis still acts as a separator, so the separation decision must be retained before ellipsis expansion.

## Testing

- `pytest -q tests/unit/test_indexing_slicing_comprehensive.py` (`59 passed, 1 skipped`)
- `pytest -q tests/unit/test_tensor_api.py -k "expand_dims or transpose or test_take"` (`43 passed`)
- compiler-backed regression cases for constant/dynamic, multidimensional, `newaxis`, empty-ellipsis, separated, and contiguous layouts
- compared shapes across 256 scalar/slice layouts and 30 zero-width-ellipsis layouts
- compared modeled lowered values and shapes with NumPy across 286 layouts

I did not have Trainium hardware or the NKIGen builder available, so local validation covered HLO tracing and `neuronx-cc` compilation rather than device execution. I also proved the general separated-axis mismatch and corrective block move separately with [TorchLean](https://github.com/lean-dojo/TorchLean); I can attach that formalization if useful.