### PR TITLE
fix: handle prepend and append in np.diff

### DIFF
--- a/nkipy/src/nkipy/core/ops/_hlo_impls.py
+++ b/nkipy/src/nkipy/core/ops/_hlo_impls.py
@@ -1602,16 +1602,118 @@ def pad(x, pad_width, mode="constant", constant_values=0, **kwargs):
         )
 
 
+def _prepare_diff_boundary(ctx, value, input_shape, axis, dtype):
+    if isinstance(value, NKIPyTensorRef):
+        boundary = value.backend_tensor
+    else:
+        if not np.isscalar(value) and not isinstance(value, np.ndarray):
+            value = np.asarray(value)
+        boundary = as_hlo_tensor(ctx, value, dtype)
+
+    if boundary.dtype != dtype:
+        boundary = ctx.build_op("convert", [boundary], boundary.shape, dtype)
+
+    if len(boundary.shape) == 0:
+        boundary_shape = list(input_shape)
+        boundary_shape[axis] = 1
+        return ctx.build_op(
+            "broadcast",
+            [boundary],
+            tuple(boundary_shape),
+            dtype,
+            {"broadcast_dimensions": []},
+        )
+
+    if len(boundary.shape) != len(input_shape):
+        raise ValueError(
+            "prepend and append must be scalars or have the same rank as the input"
+        )
+
+    for dim, (boundary_size, input_size) in enumerate(
+        zip(boundary.shape, input_shape)
+    ):
+        if dim != axis and boundary_size != input_size:
+            raise ValueError(
+                "prepend and append must match the input shape on every "
+                "dimension except the differencing axis"
+            )
+
+    return boundary
+
+
 def diff(a, n=1, axis=-1, prepend=None, append=None):
     from nkipy.core.ops.binary import subtract as sub_op
 
     ctx = get_hlo_context()
 
+    if n < 0:
+        raise ValueError(f"order must be non-negative but got {n}")
+
     ndim = len(a.shape)
     if axis < 0:
         axis += ndim
+    if axis < 0 or axis >= ndim:
+        raise ValueError(f"axis {axis} is out of bounds for array of dimension {ndim}")
 
-    result = a
+    if n == 0:
+        return a
+
+    boundaries = []
+    if prepend is not None:
+        if not np.isscalar(prepend) and not isinstance(
+            prepend, (NKIPyTensorRef, np.ndarray)
+        ):
+            prepend = np.asarray(prepend)
+        boundaries.append(prepend)
+    if append is not None:
+        if not np.isscalar(append) and not isinstance(
+            append, (NKIPyTensorRef, np.ndarray)
+        ):
+            append = np.asarray(append)
+        boundaries.append(append)
+
+    result_dtype = a.dtype
+    dtype_probe = a
+    for boundary in boundaries:
+        result_dtype = find_common_type_hlo(dtype_probe, boundary)
+        dtype_probe = np.empty((), dtype=result_dtype)
+
+    a_tensor = a.backend_tensor if isinstance(a, NKIPyTensorRef) else a
+    if a_tensor.dtype != result_dtype:
+        a_tensor = ctx.build_op(
+            "convert", [a_tensor], a_tensor.shape, result_dtype
+        )
+
+    parts = []
+    if prepend is not None:
+        parts.append(
+            _prepare_diff_boundary(
+                ctx, prepend, a_tensor.shape, axis, result_dtype
+            )
+        )
+    parts.append(a_tensor)
+    if append is not None:
+        parts.append(
+            _prepare_diff_boundary(
+                ctx, append, a_tensor.shape, axis, result_dtype
+            )
+        )
+
+    if len(parts) > 1:
+        concatenated_shape = list(a_tensor.shape)
+        concatenated_shape[axis] = builtins.sum(part.shape[axis] for part in parts)
+        result = NKIPyTensorRef(
+            ctx.build_op(
+                "concatenate",
+                parts,
+                tuple(concatenated_shape),
+                result_dtype,
+                {"dimension": axis},
+            )
+        )
+    else:
+        result = NKIPyTensorRef(a_tensor)
+
     for _ in range(n):
         if isinstance(result, NKIPyTensorRef):
             r_bt = result.backend_tensor

--- a/tests/unit/test_tensor_api.py
+++ b/tests/unit/test_tensor_api.py
@@ -18,6 +18,7 @@ except ImportError:
     TORCH_AVAILABLE = False
 
 from nkipy.core import tensor_apis
+from nkipy.core.trace import NKIPyKernel
 from utils import (
     NEURON_AVAILABLE,
     baremetal_assert_allclose,
@@ -3369,6 +3370,74 @@ def test_diff_n2(trace_mode):
     shape = (32, 64)
     in0 = np.random.uniform(0.0, 1.0, size=shape).astype(np.float32)
     expected = kernel(in0)
+    if NEURON_AVAILABLE:
+        out_device = on_device_test(kernel, trace_mode, in0)
+        baremetal_assert_allclose(expected, out_device)
+    else:
+        trace_and_compile(kernel, trace_mode, in0)
+
+
+def test_diff_with_scalar_prepend_and_append(trace_mode):
+    def kernel(a):
+        return np.diff(
+            a,
+            axis=-1,
+            prepend=np.float32(0.0),
+            append=np.float32(25.0),
+        )
+
+    in0 = np.array([[1.0, 4.0, 9.0, 16.0]], dtype=np.float16)
+    expected = kernel(in0)
+
+    traced = NKIPyKernel.trace(kernel, backend=trace_mode).specialize(in0)
+    assert traced.outputs[0].shape == expected.shape
+    assert traced.outputs[0].dtype == expected.dtype
+    assert any(op.op_name == "concatenate" for op in traced.operations)
+
+    if NEURON_AVAILABLE:
+        out_device = on_device_test(kernel, trace_mode, in0)
+        baremetal_assert_allclose(expected, out_device)
+    else:
+        trace_and_compile(kernel, trace_mode, in0)
+
+
+def test_diff_with_tensor_prepend_and_append(trace_mode):
+    def kernel(a, prepend, append):
+        return np.diff(a, axis=0, prepend=prepend, append=append)
+
+    in0 = np.array([[1.0, 4.0], [9.0, 16.0]], dtype=np.float32)
+    prepend = np.array([[0.0, 1.0]], dtype=np.float32)
+    append = np.array([[25.0, 36.0], [49.0, 64.0]], dtype=np.float32)
+    expected = kernel(in0, prepend, append)
+
+    traced = NKIPyKernel.trace(kernel, backend=trace_mode).specialize(
+        in0, prepend, append
+    )
+    assert traced.outputs[0].shape == expected.shape
+
+    if NEURON_AVAILABLE:
+        out_device = on_device_test(kernel, trace_mode, in0, prepend, append)
+        baremetal_assert_allclose(expected, out_device)
+    else:
+        trace_and_compile(kernel, trace_mode, in0, prepend, append)
+
+
+def test_diff_n2_applies_boundaries_once(trace_mode):
+    def kernel(a):
+        return np.diff(
+            a,
+            n=2,
+            prepend=np.float32(0.0),
+            append=np.float32(25.0),
+        )
+
+    in0 = np.array([1.0, 4.0, 9.0, 16.0], dtype=np.float32)
+    expected = kernel(in0)
+
+    traced = NKIPyKernel.trace(kernel, backend=trace_mode).specialize(in0)
+    assert traced.outputs[0].shape == expected.shape
+    assert sum(op.op_name == "concatenate" for op in traced.operations) == 1
+
     if NEURON_AVAILABLE:
         out_device = on_device_test(kernel, trace_mode, in0)
         baremetal_assert_allclose(expected, out_device)


### PR DESCRIPTION
## Summary

- apply scalar and tensor `prepend` and `append` values before differencing
- concatenate boundaries once so higher-order differences match NumPy
- preserve promoted dtypes and validate non-axis dimensions
- add regressions for scalar, tensor, non-last-axis, and second-order differences

## Problem

The HLO implementation accepted `prepend` and `append` but never used them. For example, `np.diff([1, 4, 9, 16], prepend=0)` traced with shape `(3,)` instead of NumPy's `(4,)`, silently dropping the requested boundary value.

## Testing

- `pytest -q tests/unit/test_tensor_api.py -k "diff or concatenate"` (`9 passed`)
- compared emitted HLO values and layouts with NumPy across 97 cases
- compiled the regression kernels for `trn2` with NeuronX Compiler 2.26

I did not have Trainium hardware available, so validation covered HLO semantics and compilation rather than device execution.