### PR TITLE
fix: handle initial and dtype in reductions

### DIFF
--- a/nkipy/src/nkipy/core/ops/_hlo_impls.py
+++ b/nkipy/src/nkipy/core/ops/_hlo_impls.py
@@ -389,6 +389,11 @@ def _build_reduction_hlo(
     if isinstance(x, NKIPyTensorRef):
         x = x.backend_tensor
 
+    if dtype is not None:
+        reduction_dtype = np.dtype(dtype)
+        if x.dtype != reduction_dtype:
+            x = ctx.build_op("convert", [x], x.shape, reduction_dtype)
+
     reduce_op_map = {
         np.sum: "add",
         np.max: "maximum",
@@ -425,9 +430,18 @@ def _build_reduction_hlo(
         "minimum": float("inf"),
         "multiply": 1.0,
     }
-    init_value = init_values[hlo_op]
+    init_value = init_values[hlo_op] if initial is None else initial
 
-    init_tensor = as_hlo_tensor(ctx, init_value, x.dtype)
+    if isinstance(init_value, NKIPyTensorRef):
+        init_tensor = init_value.backend_tensor
+        if init_tensor.shape != ():
+            raise ValueError("initial must be a scalar")
+        if init_tensor.dtype != x.dtype:
+            init_tensor = ctx.build_op("convert", [init_tensor], (), x.dtype)
+    else:
+        if isinstance(init_value, np.ndarray) and init_value.shape != ():
+            raise ValueError("initial must be a scalar")
+        init_tensor = as_hlo_tensor(ctx, init_value, x.dtype)
 
     result_tensor = ctx.build_op(
         "reduce",

--- a/tests/unit/test_tensor_api.py
+++ b/tests/unit/test_tensor_api.py
@@ -371,6 +371,56 @@ def test_reduction(trace_mode, np_fn, shape, dtype, axis):
         trace_and_compile(kernel, trace_mode, in0)
 
 
+@pytest.mark.parametrize(
+    "np_fn,initial",
+    [
+        (np.sum, np.float32(10.0)),
+        (np.prod, np.float32(2.0)),
+        (np.max, np.float32(20.0)),
+        (np.min, np.float32(-5.0)),
+    ],
+)
+def test_reduction_initial(trace_mode, np_fn, initial):
+    def kernel(a):
+        return np_fn(a, axis=1, initial=initial)
+
+    in0 = np.array([[1.0, 4.0], [9.0, 16.0]], dtype=np.float32)
+    expected = kernel(in0)
+
+    traced = NKIPyKernel.trace(kernel, backend=trace_mode).specialize(in0)
+    reduce_op = next(op for op in traced.operations if op.op_name == "reduce")
+    init_op = reduce_op.operands[1].source_op
+    assert init_op.op_name == "constant"
+    assert init_op.attributes["value"] == pytest.approx(float(initial))
+
+    if NEURON_AVAILABLE:
+        out_device = on_device_test(kernel, trace_mode, in0)
+        baremetal_assert_allclose(expected, out_device)
+    else:
+        trace_and_compile(kernel, trace_mode, in0)
+
+
+@pytest.mark.parametrize("np_fn", [np.sum, np.prod])
+def test_reduction_dtype(trace_mode, np_fn):
+    def kernel(a):
+        return np_fn(a, axis=1, dtype=np.float16)
+
+    in0 = np.array([[1.0, 4.0], [9.0, 16.0]], dtype=np.float32)
+    expected = kernel(in0)
+
+    traced = NKIPyKernel.trace(kernel, backend=trace_mode).specialize(in0)
+    reduce_op = next(op for op in traced.operations if op.op_name == "reduce")
+    assert traced.outputs[0].dtype == expected.dtype
+    assert reduce_op.operands[0].dtype == expected.dtype
+    assert reduce_op.operands[1].dtype == expected.dtype
+
+    if NEURON_AVAILABLE:
+        out_device = on_device_test(kernel, trace_mode, in0)
+        baremetal_assert_allclose(expected, out_device)
+    else:
+        trace_and_compile(kernel, trace_mode, in0)
+
+
 def test_multiple_sum_different_dtypes(trace_mode):
     """Test multiple np.sum calls with different dtypes.
 


### PR DESCRIPTION
## Summary

- cast reduction inputs when `dtype` is specified
- use the caller-provided `initial` value instead of always using the identity
- validate tensor and array initializers are scalar
- add coverage for `sum`, `prod`, `max`, and `min` initial values and explicit reduction dtypes

## Problem

The HLO reduction helper accepted `initial` and `dtype` but ignored both. As a result, `np.sum(x, initial=10)` still initialized the reduction with zero, and `np.sum(x, dtype=np.float16)` still returned `float32`. The resulting HLO compiled successfully but had different semantics from NumPy.

## Testing

- `pytest -q tests/unit/test_tensor_api.py -k "reduction or prod"` (`30 passed`)
- compared emitted HLO values, shapes, and dtypes with NumPy across 48 cases
- compiled the regression kernels for `trn2` with NeuronX Compiler 2.26

I did not have Trainium hardware available, so validation covered HLO semantics and compilation rather than device execution.