### PR TITLE
fix(runtime): materialize zero-element outputs on host

### DIFF
--- a/nkipy/src/nkipy/runtime/execute.py
+++ b/nkipy/src/nkipy/runtime/execute.py
@@ -96,9 +96,17 @@ def _execute_neff(neff, name, ir: ComputationIR, original_inputs, save_trace=Fal
     }
 
     device_outputs = {}
+    # Zero-element outputs (e.g. from an empty slice) are dropped by the
+    # compiler and are absent from the NEFF; nrt also rejects 0-byte tensor
+    # allocations. Materialize them directly on the host instead.
+    empty_outputs = {}
     for i, outtensor in enumerate(ir.outputs):
         if i in alias_input_names:
             device_outputs[outtensor.name] = device_inputs[alias_input_names[i]]
+        elif int(np.prod(outtensor.shape)) == 0:
+            empty_outputs[outtensor.name] = np.zeros(
+                outtensor.shape, dtype=outtensor.dtype
+            )
         else:
             np_output = np.zeros(outtensor.shape, dtype=outtensor.dtype)
             device_outputs[outtensor.name] = DeviceTensor.from_numpy(np_output)
@@ -108,7 +116,10 @@ def _execute_neff(neff, name, ir: ComputationIR, original_inputs, save_trace=Fal
     output_arrays = {}
     alias_by_output = {a.output_index: a for a in ir.aliases}
     for i, outtensor in enumerate(ir.outputs):
-        result = device_outputs[outtensor.name].numpy()
+        if outtensor.name in empty_outputs:
+            result = empty_outputs[outtensor.name]
+        else:
+            result = device_outputs[outtensor.name].numpy()
         if i in alias_by_output:
             alias = alias_by_output[i]
             np.copyto(dst=original_inputs[alias.param_name], src=result)


### PR DESCRIPTION
## Problem

Three `test_empty_slice` unit tests fail on the `hlo` backend. They slice a 32-element tensor down to **0 elements** (`a[40:50]`, `a[5:3]`, `a[3:5:-1]`), producing an output of shape `(0,)`.

The compiler drops zero-element outputs entirely — the compiled NEFF declares no outputs. But `_execute_neff` still iterated `ir.outputs` and called `DeviceTensor.from_numpy(np.zeros((0,)))`, asking NRT to allocate a **0-byte device tensor**. NRT rejects that:

```
spike._spike.NrtError: NRT Error NRT_RESOURCE(4): Failed to allocate tensor
```

## Fix

`_execute_neff` now detects zero-element (non-aliased) outputs and materializes them directly on the host, skipping device allocation and readback. Aliased and normal outputs are unaffected.

## Testing

- The 3 previously-failing `test_empty_slice` cases now pass.
- Full unit suite: **793 passed, 16 skipped, 4 xfailed** (was 790 passed / 3 failed), no regressions.