### PR TITLE
fix: promote mixed dtypes in np.concatenate

### DIFF
--- a/nkipy/src/nkipy/core/ops/_hlo_impls.py
+++ b/nkipy/src/nkipy/core/ops/_hlo_impls.py
@@ -1333,6 +1333,11 @@ def concatenate(tensors, axis=0):
     for t in hlo_tensors[1:]:
         dtype = np.result_type(dtype, t.dtype)
 
+    hlo_tensors = [
+        (ctx.build_op("convert", [t], t.shape, dtype) if t.dtype != dtype else t)
+        for t in hlo_tensors
+    ]
+
     result_tensor = ctx.build_op(
         "concatenate", hlo_tensors, output_shape, dtype, {"dimension": axis}
     )

--- a/tests/unit/test_tensor_api.py
+++ b/tests/unit/test_tensor_api.py
@@ -1756,6 +1756,48 @@ def test_concatenate(trace_mode):
         trace_and_compile(kernel, trace_mode, in0, in1)
 
 
+def test_concatenate_promotes_mixed_tensor_dtypes(trace_mode):
+    """Concatenate converts tensor operands to the promoted result dtype."""
+
+    def kernel(a, b):
+        return np.concatenate([a, b], axis=0)
+
+    in0 = np.random.random_sample((32, 64)).astype(np.float16)
+    in1 = np.random.random_sample((16, 64)).astype(np.float32)
+    expected = kernel(in0, in1)
+
+    traced = NKIPyKernel.trace(kernel, backend=trace_mode).specialize(in0, in1)
+    assert traced.outputs[0].shape == expected.shape
+    assert traced.outputs[0].dtype == expected.dtype
+
+    if NEURON_AVAILABLE:
+        out_device = on_device_test(kernel, trace_mode, in0, in1)
+        baremetal_assert_allclose(expected, out_device)
+    else:
+        trace_and_compile(kernel, trace_mode, in0, in1)
+
+
+def test_concatenate_promotes_tensor_and_numpy_constant(trace_mode):
+    """Concatenate promotes a tensor parameter and NumPy constant."""
+    constant = np.ones((16, 64), dtype=np.float32)
+
+    def kernel(a):
+        return np.concatenate([a, constant], axis=0)
+
+    in0 = np.random.random_sample((32, 64)).astype(np.float16)
+    expected = kernel(in0)
+
+    traced = NKIPyKernel.trace(kernel, backend=trace_mode).specialize(in0)
+    assert traced.outputs[0].shape == expected.shape
+    assert traced.outputs[0].dtype == expected.dtype
+
+    if NEURON_AVAILABLE:
+        out_device = on_device_test(kernel, trace_mode, in0)
+        baremetal_assert_allclose(expected, out_device)
+    else:
+        trace_and_compile(kernel, trace_mode, in0)
+
+
 def test_concatenate_single_tensor(trace_mode):
     """Test np.concatenate with a single tensor."""
 


### PR DESCRIPTION
## Summary

- convert each `concatenate` operand to NumPy's promoted result dtype before emitting HLO
- preserve the existing output shape and dtype behavior
- add regressions for mixed tensor inputs and tensor/NumPy-constant inputs

## Problem

`np.concatenate` computed a promoted output dtype but passed the original operands to the HLO instruction unchanged. For example, concatenating `float16` and `float32` inputs emitted an `f32` concatenate with one `f16` operand:

```text
f32[48,64] concatenate(f16[32,64], f32[16,64])
```

This is a valid NumPy operation, but the generated HLO is invalid and NeuronX Compiler rejects it with `NCC_IVRF100`. Converting each operand to the promoted dtype makes the HLO instruction internally consistent.

## Testing

- `uv run pytest -q tests/unit/test_tensor_api.py -k "concatenate"` (`5 passed`)
- confirmed both new regressions fail against unmodified `add2c20` and pass with this change
- compiled the regression kernels for `trn2` with NeuronX Compiler 2.26.6360
- `git diff --check`

I did not have Trainium hardware available, so local validation covered HLO tracing and `neuronx-cc` compilation rather than device execution.