### PR TITLE
fix: normalize negative axes in np.transpose

### DIFF
--- a/nkipy/src/nkipy/core/ops/_hlo_impls.py
+++ b/nkipy/src/nkipy/core/ops/_hlo_impls.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import builtins
 import itertools
+import operator
 from typing import List, Tuple
 
 import numpy as np
@@ -1214,8 +1215,24 @@ def transpose(x, axes=None, out=None, dtype=None):
     if isinstance(x, NKIPyTensorRef):
         x = x.backend_tensor
 
+    ndim = len(x.shape)
     if axes is None:
-        axes = list(range(len(x.shape)))[::-1]
+        axes = tuple(range(ndim - 1, -1, -1))
+    else:
+        axes = tuple(axes)
+        if len(axes) != ndim:
+            raise ValueError("axes don't match array")
+
+        normalized_axes = []
+        for axis in axes:
+            axis = operator.index(axis)
+            if axis < -ndim or axis >= ndim:
+                raise np.exceptions.AxisError(axis, ndim)
+            normalized_axes.append(axis % ndim)
+        axes = tuple(normalized_axes)
+
+        if len(set(axes)) != ndim:
+            raise ValueError("repeated axis in transpose")
 
     result_shape = tuple(x.shape[i] for i in axes)
 

--- a/tests/unit/test_tensor_api.py
+++ b/tests/unit/test_tensor_api.py
@@ -599,6 +599,48 @@ def test_transpose(trace_mode, shape, axes):
 
 
 @pytest.mark.parametrize(
+    "shape,axes",
+    [
+        ((2, 3), (-1, -2)),
+        ((2, 3, 4), (1, -1, 0)),
+    ],
+)
+def test_transpose_negative_axes(trace_mode, shape, axes):
+    def kernel(a):
+        return np.transpose(a, axes=axes)
+
+    in0 = np.random.random_sample(shape).astype(np.float32)
+    expected = kernel(in0)
+
+    traced = NKIPyKernel.trace(kernel, backend=trace_mode).specialize(in0)
+    assert traced.outputs[0].shape == expected.shape
+    assert traced.outputs[0].dtype == expected.dtype
+
+    if NEURON_AVAILABLE:
+        out_device = on_device_test(kernel, trace_mode, in0)
+        baremetal_assert_allclose(expected, out_device)
+    else:
+        trace_and_compile(kernel, trace_mode, in0)
+
+
+@pytest.mark.parametrize(
+    "axes,error_type,error_match",
+    [
+        ((0,), ValueError, "axes don't match array"),
+        ((0, 0), ValueError, "repeated axis in transpose"),
+        ((0, 2), np.exceptions.AxisError, "axis 2 is out of bounds"),
+    ],
+)
+def test_transpose_invalid_axes(trace_mode, axes, error_type, error_match):
+    def kernel(a):
+        return np.transpose(a, axes=axes)
+
+    in0 = np.ones((2, 3), dtype=np.float32)
+    with pytest.raises(error_type, match=error_match):
+        NKIPyKernel.trace(kernel, backend=trace_mode).specialize(in0)
+
+
+@pytest.mark.parametrize(
     "shape,repeats,axis",
     [
         ((2, 3), 2, 0),


### PR DESCRIPTION
## Summary

- normalize negative transpose axes before emitting the HLO permutation
- validate permutation length, bounds, and duplicate axes with NumPy-compatible errors
- add compiler-backed regressions for negative, mixed-sign, and invalid permutations

## Problem

NumPy accepts negative axes in transpose permutations, but NKIPy forwarded them directly to HLO. For example:

```python
np.transpose(a, axes=(-1, -2))
```

produced `dimensions={-1,-2}` instead of `dimensions={1,0}`. The call is valid in NumPy, but NeuronX Compiler rejects the generated HLO with `NCC_IVRF100`.

## Testing

- `uv run pytest -q tests/unit/test_tensor_api.py -k "transpose"` (`11 passed`)
- confirmed both negative-axis regressions fail against unmodified `add2c20` and pass with this change
- checked invalid-permutation behavior with NumPy 1.26.4, the project minimum (`3 passed`)
- compiled the regression kernels for `trn2` with NeuronX Compiler 2.26.6360
- `git diff --check`

I did not have Trainium hardware available, so local validation covered HLO tracing and `neuronx-cc` compilation rather than device execution.