### PR TITLE
fix: broadcast shift and axis in np.roll

### DIFF
--- a/nkipy/src/nkipy/core/ops/_hlo_impls.py
+++ b/nkipy/src/nkipy/core/ops/_hlo_impls.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import builtins
 import itertools
+import operator
 from typing import List, Tuple
 
 import numpy as np
@@ -1824,20 +1825,34 @@ def roll(x, shift, axis=None):
     if axis is None:
         total = int(np.prod(x_shape))
         flat = reshape_op(x, (total,))
-        rolled = _roll_single_axis(flat, shift, 0)
+        rolled = roll(flat, shift, 0)
         return reshape_op(rolled, x_shape)
 
-    if isinstance(shift, (list, tuple)):
-        if not isinstance(axis, (list, tuple)):
-            raise ValueError("If shift is a tuple, axis must also be a tuple")
-        result = x
-        for s, a in zip(shift, axis):
-            result = _roll_single_axis(result, s, a if a >= 0 else a + ndim)
-        return result
+    if isinstance(axis, (int, np.integer)):
+        axes = (operator.index(axis),)
+    else:
+        axes = tuple(axis)
 
-    if axis < 0:
-        axis += ndim
-    return _roll_single_axis(x, shift, axis)
+    normalized_axes = []
+    for ax in axes:
+        ax = operator.index(ax)
+        if ax < -ndim or ax >= ndim:
+            raise np.exceptions.AxisError(ax, ndim)
+        normalized_axes.append(ax % ndim)
+
+    broadcasted = np.broadcast(shift, tuple(normalized_axes))
+    if broadcasted.ndim > 1:
+        raise ValueError("'shift' and 'axis' should be scalars or 1D sequences")
+
+    shifts = dict.fromkeys(range(ndim), 0)
+    for amount, ax in broadcasted:
+        shifts[ax] += int(amount)
+
+    result = x
+    for ax, amount in shifts.items():
+        if amount:
+            result = _roll_single_axis(result, amount, ax)
+    return result
 
 
 def _roll_single_axis(x, shift, axis):

--- a/tests/unit/test_tensor_api.py
+++ b/tests/unit/test_tensor_api.py
@@ -3529,6 +3529,47 @@ def test_roll_axis0(trace_mode):
         trace_and_compile(kernel, trace_mode, in0)
 
 
+@pytest.mark.parametrize(
+    "shift,axis,expected_concatenate_axes",
+    [
+        ((1,), (0, 1), [0, 1]),
+        (1, (0, 1), [0, 1]),
+        ((1, 2), 0, [0]),
+        ((1, 2), None, [0]),
+    ],
+)
+def test_roll_broadcasts_shift_and_axis(
+    trace_mode, shift, axis, expected_concatenate_axes
+):
+    def kernel(a):
+        return np.roll(a, shift, axis=axis)
+
+    in0 = np.arange(32 * 64, dtype=np.float32).reshape(32, 64)
+    expected = kernel(in0)
+    traced = NKIPyKernel.trace(kernel, backend=trace_mode).specialize(in0)
+    concatenate_axes = [
+        op.attributes["dimension"]
+        for op in traced.operations
+        if op.op_name == "concatenate"
+    ]
+    assert concatenate_axes == expected_concatenate_axes
+
+    if NEURON_AVAILABLE:
+        out_device = on_device_test(kernel, trace_mode, in0)
+        baremetal_assert_allclose(expected, out_device)
+    else:
+        trace_and_compile(kernel, trace_mode, in0)
+
+
+def test_roll_rejects_non_broadcastable_shift_and_axis(trace_mode):
+    def kernel(a):
+        return np.roll(a, (1, 2, 3), axis=(0, 1))
+
+    in0 = np.ones((32, 64), dtype=np.float32)
+    with pytest.raises(ValueError, match="shape mismatch"):
+        NKIPyKernel.trace(kernel, backend=trace_mode).specialize(in0)
+
+
 def test_isnan(trace_mode):
     def kernel(a):
         # Return as float since bool output is tricky


### PR DESCRIPTION
## Summary

- broadcast `shift` and `axis` using NumPy-compatible rules
- normalize negative axes, accumulate repeated axes, and reject incompatible shapes
- handle tuple shifts consistently when `axis=None`
- add focused regressions for scalar, singleton, tuple, and invalid combinations

## Problem

I ran into a few valid `np.roll` calls that either failed during tracing or silently rolled the wrong axes. For example:

```python
np.roll(a, 1, axis=(0, 1))
```

NumPy applies the scalar shift to both axes, while the current implementation tries to compare the axis tuple with an integer and raises `TypeError`. Similarly, `shift=(1,)` with `axis=(0, 1)` silently rolls only the first axis because the two values are paired with `zip`.

This change follows NumPy's broadcast-and-accumulate behavior, so scalar and one-element shifts expand correctly, repeated axes are combined, and non-broadcastable inputs raise instead of being truncated.

## Testing

- `uv run pytest -q -n 0 tests/unit/test_tensor_api.py -k roll` (`7 passed`)
- confirmed all five new regression cases fail against unmodified `add2c20`
- evaluated the emitted HLO graph against NumPy for 14 valid shift/axis combinations and checked four invalid combinations
- compiled the regression kernels for `trn2` with NeuronX Compiler 2.26.6360
- `git diff --check`

I do not have Trainium hardware available, so local validation covered HLO semantics and `neuronx-cc` compilation rather than device execution.