### PR TITLE
fix(indexing): normalize NumPy scalar indices

### DIFF
--- a/nkipy/src/nkipy/core/tensor.py
+++ b/nkipy/src/nkipy/core/tensor.py
@@ -298,6 +298,16 @@ def _expand_ellipsis(indices: tuple, ndim: int) -> tuple:
     return new_indices
 
 
+def _normalize_scalar_indices(indices: tuple) -> tuple:
+    """Convert NumPy integer scalars while rejecting boolean scalar indexing."""
+    normalized = []
+    for idx in indices:
+        if isinstance(idx, (bool, np.bool_)):
+            raise NotImplementedError("Boolean scalar indexing is not supported.")
+        normalized.append(int(idx) if isinstance(idx, np.integer) else idx)
+    return tuple(normalized)
+
+
 def _strip_newaxis(indices: tuple) -> tuple:
     """Remove None (np.newaxis) from indices; return cleaned indices and expand axes."""
     cleaned = []
@@ -532,6 +542,7 @@ class NKIPyTensorRef(TensorArithmeticMixin, TensorOperationMixin):
             # Normalize indices to a tuple
             if not isinstance(indices, tuple):
                 indices = (indices,)
+            indices = _normalize_scalar_indices(indices)
 
             advanced_indices_are_separated = _advanced_indices_are_separated(indices)
             indices = _expand_ellipsis(indices, len(self.shape))
@@ -724,6 +735,7 @@ class NKIPyTensorRef(TensorArithmeticMixin, TensorOperationMixin):
             # Normalize indices to a tuple
             if not isinstance(indices, tuple):
                 indices = (indices,)
+            indices = _normalize_scalar_indices(indices)
 
             if any(idx is None for idx in indices):
                 raise IndexError(

--- a/tests/unit/test_indexing_slicing_comprehensive.py
+++ b/tests/unit/test_indexing_slicing_comprehensive.py
@@ -380,6 +380,41 @@ class TestIndexingSlicingAdvanced:
             out_baremetal = on_device_test(kernel, trace_mode, a)
             baremetal_assert_allclose(expected, out_baremetal)
 
+    @pytest.mark.parametrize("scalar_type", [np.int32, np.int64])
+    @pytest.mark.parametrize("index", [1, -1])
+    def test_numpy_integer_scalar_index(
+        self, trace_mode, sample_tensors, scalar_type, index
+    ):
+        numpy_index = scalar_type(index)
+
+        def kernel(a):
+            return a[:, numpy_index, :]
+
+        a = sample_tensors["small_3d"]
+        expected = kernel(a)
+
+        if NEURON_AVAILABLE:
+            out_baremetal = on_device_test(kernel, trace_mode, a)
+            baremetal_assert_allclose(expected, out_baremetal)
+        else:
+            _assert_traced_shape(kernel, trace_mode, expected.shape, a)
+            trace_and_compile(kernel, trace_mode, a)
+
+    def test_numpy_integer_scalar_assignment(self, trace_mode, sample_tensors):
+        def kernel(a, b):
+            a[:, np.int64(1)] = b
+            return a
+
+        a = sample_tensors["small_2d"]
+        b = np.ones(a[:, 1].shape, dtype=np.float32)
+        expected = kernel(a.copy(), b)
+
+        if NEURON_AVAILABLE:
+            out_baremetal = on_device_test(kernel, trace_mode, a.copy(), b)
+            baremetal_assert_allclose(expected, out_baremetal)
+        else:
+            trace_and_compile(kernel, trace_mode, a.copy(), b)
+
     def test_negative_slice_indexing(self, trace_mode, sample_tensors):
         def kernel(a):
             view = a[:-2, 1:-1]
@@ -872,6 +907,35 @@ class TestIndexingSlicingErrorHandling:
                 on_device_test(kernel, trace_mode, a)
             else:
                 trace_and_compile(kernel, trace_mode, a)
+
+    @pytest.mark.parametrize(
+        "boolean_index", [True, False, np.bool_(True), np.bool_(False)]
+    )
+    def test_boolean_scalar_index_unsupported(
+        self, trace_mode, sample_tensors, boolean_index
+    ):
+        def kernel(a):
+            return a[boolean_index]
+
+        a = sample_tensors["small_2d"]
+
+        with pytest.raises(NotImplementedError, match="Boolean scalar indexing"):
+            NKIPyKernel.trace(kernel, backend=trace_mode).specialize(a)
+
+    @pytest.mark.parametrize(
+        "boolean_index", [True, False, np.bool_(True), np.bool_(False)]
+    )
+    def test_boolean_scalar_assignment_unsupported(
+        self, trace_mode, sample_tensors, boolean_index
+    ):
+        def kernel(a):
+            a[boolean_index] = 0.0
+            return a
+
+        a = sample_tensors["small_2d"]
+
+        with pytest.raises(NotImplementedError, match="Boolean scalar indexing"):
+            NKIPyKernel.trace(kernel, backend=trace_mode).specialize(a)
 
     def test_newaxis_in_setitem_error(self, trace_mode, sample_tensors):
         def kernel(a):


### PR DESCRIPTION
## Summary

- normalize NumPy integer scalars before static indexing and assignment
- reject Python and NumPy boolean scalars consistently with the documented boolean-indexing limitation
- add regressions for positive and negative integer indices, assignment, and both boolean values

## Problem

I ran into a valid NumPy indexing pattern that nkiPy currently rejects:

```python
a[:, np.int64(1), :]
```

The static indexing path only recognizes Python `int`, so NumPy integer scalars reach it as unsupported index types. The same issue affects assignment and can produce malformed `dynamic-update-slice` HLO that `neuronx-cc` rejects.

There is a related scalar-type edge case: Python booleans are subclasses of `int`, so `a[True]` is currently interpreted as integer index `1`. That silently differs from NumPy boolean indexing. Since boolean indexing is already documented as unsupported, this change rejects Python and NumPy boolean scalars explicitly instead of treating them as integer indices.

## Testing

- `uv run pytest -q -n 0 tests/unit/test_indexing_slicing_comprehensive.py` (`72 passed, 1 skipped`)
- focused scalar-index regressions (`13 passed`)
- confirmed all 13 focused cases fail against unmodified `add2c20`
- compiled the integer-index read and assignment regressions for `trn2` with NeuronX Compiler 2.26.6360
- `ruff format --check` and `git diff --check`

I do not have Trainium hardware available, so local validation covered HLO tracing and `neuronx-cc` compilation rather than device execution.