### PR TITLE
fix(nki): bind non-tensor and keyword args correctly for beta 3 kernels

### DIFF
--- a/nkipy/src/nkipy/core/nki_op.py
+++ b/nkipy/src/nkipy/core/nki_op.py
@@ -421,15 +421,32 @@ def _build_hlo_custom_call(config, operands):
     )
 
 
+def _beta3_is_device_input(value):
+    """Whether a beta 3 kernel argument becomes a device (HBM) input tensor.
+
+    Mirrors ``nki.compiler.frontend._classify_kernel_args``: only ndarray-like
+    values become BIR input tensors. Everything else (python/numpy scalars,
+    tuples, dtypes, enums, ...) is a trace-time constant that NKI specializes
+    into the compiled kernel and that must NOT be passed as a custom-call
+    operand.
+    """
+    return isinstance(value, (np.ndarray, NKIPyTensorRef))
+
+
 def _build_hlo_custom_call_beta3(framework_config, is_tuple_return, operands):
-    """Build HLO custom-call operation from a beta 3 FrameworkConfig."""
+    """Build HLO custom-call operation from a beta 3 FrameworkConfig.
+
+    Non-tensor values in ``operands`` are trace-time constants that NKI already
+    specialized into ``framework_config``; they are not device inputs, so they
+    are dropped here rather than forwarded to the custom-call. Passing them
+    through would shift every later operand and make the kernel read the wrong
+    buffers.
+    """
     if get_backend() != "hlo":
         raise NotImplementedError("Modes other than HLO are not implemented yet")
 
-    # Collect tensor operands (preserving order) for alias resolution
-    tensor_operands = [op for op in operands if isinstance(op, NKIPyTensorRef)]
-
-    # Build HLO operands (beta 3 handles constants internally)
+    # Device inputs, in kernel-parameter order, for alias resolution.
+    tensor_operands = [op for op in operands if _beta3_is_device_input(op)]
     hlo_operands = [op.backend_tensor for op in tensor_operands]
 
     output_shapes = [tuple(spec.shape) for spec in framework_config.output_specs]
@@ -548,12 +565,10 @@ def _generate_nki_custom_call_beta3(kernel, *args, **kwargs):
 
     framework_config, is_tuple_return = _beta3_compile_and_get_config(kernel, numpy_inputs)
 
-    # Collect tensor operands in parameter order
-    operands = [
-        v
-        for v in bound.arguments.values()
-        if isinstance(v, (NKIPyTensorRef, np.ndarray))
-    ]
+    # Device inputs in parameter order. Non-tensor arguments are trace-time
+    # constants that NKI specialized into the compiled kernel above, so they are
+    # deliberately not operands of the custom-call.
+    operands = [v for v in bound.arguments.values() if _beta3_is_device_input(v)]
     if get_backend() == "cpu":
         raise NotImplementedError("CPU execution is not supported for NKI custom ops")
     return _build_hlo_custom_call_beta3(
@@ -619,12 +634,19 @@ class NKICustomOp:
         platform_target: Optional[str] = None,
         nki_compile_mode: str = "standard",
         nisa_allocation_mode: Optional[str] = None,
+        kernel_kwargs: Optional[dict] = None,
     ):
         operands = list(operands)
         self._is_beta3 = is_nki_beta_3_version
 
         if platform_target is None:
             platform_target = _get_platform_target_default()
+
+        if kernel_kwargs and not is_nki_beta_3_version:
+            raise ValueError(
+                "kernel_kwargs is only supported by the beta 3 frontend "
+                "(is_nki_beta_3_version=True)."
+            )
 
         if is_nki_beta_3_version:
             if not BETA3_NKI_AVAILABLE:
@@ -638,6 +660,7 @@ class NKICustomOp:
                 platform_target,
                 nki_compile_mode,
                 nisa_allocation_mode,
+                kernel_kwargs=kernel_kwargs,
             )
         elif is_nki_beta_2_version:
             if not BETA2_NKI_AVAILABLE:
@@ -690,20 +713,56 @@ class NKICustomOp:
         platform_target,
         nki_compile_mode="standard",
         nisa_allocation_mode=None,
+        kernel_kwargs=None,
     ):
-        # Build inputs dict from operands matching kernel parameter names
+        # Bind the example operands to the kernel signature BY NAME, so that
+        # non-tensor arguments -- which NKI specializes into the compiled kernel
+        # at trace time -- land on the right parameter whether they are given
+        # positionally or via kernel_kwargs. Mirrors torch-neuronx's
+        # merge_tensor_constant_args: parameters named in kernel_kwargs are
+        # filled from there, and the positional operands fill the rest in order.
+        # This is what lets a kernel with a non-tensor parameter in the MIDDLE of
+        # its signature be wrapped with just its tensors.
         func = getattr(kernel, "func", kernel)
         sig = inspect.signature(func)
-        params = list(sig.parameters.keys())
+        kernel_kwargs = dict(kernel_kwargs or {})
+        unknown = set(kernel_kwargs) - set(sig.parameters)
+        if unknown:
+            raise ValueError(
+                f"kernel_kwargs names {sorted(unknown)}, which are not "
+                f"parameters of {getattr(func, '__name__', func)!r}: "
+                f"{list(sig.parameters)}"
+            )
+        positional = [p for p in sig.parameters if p not in kernel_kwargs]
+        if len(operands) > len(positional):
+            raise ValueError(
+                f"{getattr(func, '__name__', func)!r} takes {len(positional)} "
+                f"operand(s) {positional} after kernel_kwargs "
+                f"{sorted(kernel_kwargs)}, got {len(operands)}."
+            )
+        bound = sig.bind_partial(
+            **kernel_kwargs, **dict(zip(positional, operands))
+        )
+        bound.apply_defaults()
+        numpy_inputs = {
+            name: bound.arguments[name]
+            for name in sig.parameters
+            if name in bound.arguments
+        }
 
-        numpy_inputs = {}
-        op_idx = 0
-        for p in params:
-            if op_idx < len(operands):
-                numpy_inputs[p] = operands[op_idx]
-                op_idx += 1
-            else:
-                break
+        # Split the bound arguments the same way NKI's frontend does: the device
+        # inputs are the HBM operands the compiled kernel expects at call time,
+        # everything else is a constant NKI specialized into the kernel.
+        self._beta3_device_input_names = [
+            name
+            for name, value in numpy_inputs.items()
+            if _beta3_is_device_input(value)
+        ]
+        self._beta3_constant_names = [
+            name
+            for name, value in numpy_inputs.items()
+            if not _beta3_is_device_input(value)
+        ]
 
         self._beta3_framework_config, self._beta3_is_tuple_return = (
             _beta3_compile_and_get_config(
@@ -721,10 +780,42 @@ class NKICustomOp:
                 "CPU execution is not supported for NKI custom ops"
             )
         if self._is_beta3:
+            self._check_beta3_operands(operands)
             return _build_hlo_custom_call_beta3(
                 self._beta3_framework_config, self._beta3_is_tuple_return, operands
             )
         return _build_hlo_custom_call(self.config, operands)
+
+    def _check_beta3_operands(self, operands):
+        """Fail loudly on a call-time/wrap-time operand mismatch (beta 3).
+
+        The kernel is specialized at wrap time, so a call must supply exactly the
+        device inputs it was compiled for. A count mismatch otherwise reaches the
+        backend as an opaque "Unrecognized DRAM input location", and a non-tensor
+        passed at call time is silently ignored in favour of the value that was
+        compiled in.
+        """
+        expected = self._beta3_device_input_names
+        got = [op for op in operands if _beta3_is_device_input(op)]
+        if len(got) != len(expected):
+            raise ValueError(
+                f"NKI beta 3 kernel expects {len(expected)} tensor operand(s) "
+                f"{expected}, got {len(got)}."
+            )
+        extra = len(operands) - len(got)
+        if extra:
+            raise ValueError(
+                f"NKI beta 3 kernel got {extra} non-tensor operand(s) at call "
+                f"time. Non-tensor values are trace-time constants that NKI "
+                f"specializes into the kernel when it is compiled, so a value "
+                f"passed here has no effect"
+                + (
+                    f" -- {self._beta3_constant_names} were already compiled in. "
+                    if self._beta3_constant_names
+                    else ". "
+                )
+                + "Pass them to wrap_nki_kernel via kernel_kwargs instead."
+            )
 
 
 def wrap_nki_kernel(
@@ -736,6 +827,7 @@ def wrap_nki_kernel(
     platform_target: Optional[str] = None,
     nki_compile_mode: str = "standard",
     nisa_allocation_mode: Optional[str] = None,
+    kernel_kwargs: Optional[dict] = None,
 ):
     """Wrap an NKI kernel for use in NKIPy's HLO tracing flow.
 
@@ -743,7 +835,12 @@ def wrap_nki_kernel(
 
     Args:
         kernel: The NKI kernel function (or @nki.jit decorated kernel)
-        operands: Example operands (numpy arrays) for tracing (shape and dtype)
+        operands: Example operands for tracing. Tensors contribute their shape
+            and dtype. For beta 3, non-tensor values (scalars, tuples, dtypes,
+            ...) may be included positionally: they are trace-time constants
+            that NKI specializes into the compiled kernel, and they are not
+            passed as operands to the resulting op. See ``kernel_kwargs`` for
+            supplying them by name.
         grid: SPMD grid configuration (ignored if kernel is already @nki.jit with grid)
         is_nki_beta_2_version: If True, use the Beta 2 NKI frontend (nki package
                                with GenericKernel). Note: does not support CPU execution.
@@ -758,6 +855,11 @@ def wrap_nki_kernel(
             ``"max-reuse"``. ``None`` (default) uses NKI's own default
             (``"fast"``). Raises ValueError if the installed nki has no
             ``nisa-allocation-mode`` pipeline option.
+        kernel_kwargs: Beta 3 only. Extra kernel arguments bound BY NAME at
+            trace time, e.g. ``kernel_kwargs={"scale": 0.088}`` for a kernel
+            whose ``scale`` parameter is consumed while tracing. Use this rather
+            than a module-level global or ``functools.partial`` to specialize a
+            non-tensor parameter.
 
     Returns:
         NKICustomOp that can be called during HLO tracing
@@ -771,6 +873,7 @@ def wrap_nki_kernel(
         platform_target=platform_target,
         nki_compile_mode=nki_compile_mode,
         nisa_allocation_mode=nisa_allocation_mode,
+        kernel_kwargs=kernel_kwargs,
     )
 
 

--- a/nkipy/src/nkipy/core/nki_op.py
+++ b/nkipy/src/nkipy/core/nki_op.py
@@ -836,11 +836,7 @@ def wrap_nki_kernel(
     Args:
         kernel: The NKI kernel function (or @nki.jit decorated kernel)
         operands: Example operands for tracing. Tensors contribute their shape
-            and dtype. For beta 3, non-tensor values (scalars, tuples, dtypes,
-            ...) may be included positionally: they are trace-time constants
-            that NKI specializes into the compiled kernel, and they are not
-            passed as operands to the resulting op. See ``kernel_kwargs`` for
-            supplying them by name.
+            and dtype.
         grid: SPMD grid configuration (ignored if kernel is already @nki.jit with grid)
         is_nki_beta_2_version: If True, use the Beta 2 NKI frontend (nki package
                                with GenericKernel). Note: does not support CPU execution.
@@ -857,9 +853,7 @@ def wrap_nki_kernel(
             ``nisa-allocation-mode`` pipeline option.
         kernel_kwargs: Beta 3 only. Extra kernel arguments bound BY NAME at
             trace time, e.g. ``kernel_kwargs={"scale": 0.088}`` for a kernel
-            whose ``scale`` parameter is consumed while tracing. Use this rather
-            than a module-level global or ``functools.partial`` to specialize a
-            non-tensor parameter.
+            whose ``scale`` parameter is consumed while tracing.
 
     Returns:
         NKICustomOp that can be called during HLO tracing

--- a/tests/unit/test_nki.py
+++ b/tests/unit/test_nki.py
@@ -33,6 +33,7 @@ if BETA2_NKI_AVAILABLE:
 # Import beta 3 frontend
 if BETA3_NKI_AVAILABLE:
     import nki as nki_beta3
+    import nki.isa as nisa_beta3
     import nki.language as nl_beta3
 
 
@@ -629,6 +630,561 @@ def test_nki_simple_beta3_hardware():
 
     out_baremetal = on_device_test(test_func, "hlo", a, b, d)
     baremetal_assert_allclose(ref, out_baremetal)
+
+
+# ---------------------------------------------------------------------------
+# Beta 3 non-tensor (trace-time constant) arguments
+#
+# NKI's beta 3 frontend splits a kernel's arguments into device inputs (ndarrays,
+# which become HBM operands) and constants (scalars, tuples, ...), which it
+# specializes into the compiled kernel. So a constant must be supplied when the
+# kernel is COMPILED -- at wrap_nki_kernel time -- and must NOT be forwarded as an
+# operand of the resulting custom-call.
+# ---------------------------------------------------------------------------
+
+
+if BETA3_NKI_AVAILABLE:
+
+    @nki_beta3.jit
+    def _beta3_scaled_kernel(a_input, scale=1.0):
+        """Copy a_input * scale. `scale` is consumed at TRACE time."""
+        a_tile = nl_beta3.load(a_input[:, :])
+        out_tile = nl_beta3.ndarray(
+            a_tile.shape, dtype=a_tile.dtype, buffer=nl_beta3.sbuf
+        )
+        nisa_beta3.activation(dst=out_tile, op=nl_beta3.copy, data=a_tile, scale=scale)
+        output = nl_beta3.ndarray(
+            a_input.shape, dtype=a_input.dtype, buffer=nl_beta3.shared_hbm
+        )
+        nl_beta3.store(output[:, :], value=out_tile)
+        return output
+
+    @nki_beta3.jit
+    def _beta3_mid_scalar_kernel(a_input, scale, b_input):
+        """(a_input + b_input) * scale, with the constant MID-signature."""
+        a_tile = nl_beta3.load(a_input[:, :])
+        b_tile = nl_beta3.load(b_input[:, :])
+        sum_tile = nl_beta3.ndarray(
+            a_tile.shape, dtype=a_tile.dtype, buffer=nl_beta3.sbuf
+        )
+        nisa_beta3.tensor_tensor(
+            dst=sum_tile, data1=a_tile, data2=b_tile, op=nl_beta3.add
+        )
+        out_tile = nl_beta3.ndarray(
+            a_tile.shape, dtype=a_tile.dtype, buffer=nl_beta3.sbuf
+        )
+        nisa_beta3.activation(
+            dst=out_tile, op=nl_beta3.copy, data=sum_tile, scale=scale
+        )
+        output = nl_beta3.ndarray(
+            a_input.shape, dtype=a_input.dtype, buffer=nl_beta3.shared_hbm
+        )
+        nl_beta3.store(output[:, :], value=out_tile)
+        return output
+
+
+@pytest.mark.skipif(
+    not BETA3_NKI_AVAILABLE, reason="Beta 3 NKI frontend (nki >= 0.4) not available"
+)
+@pytest.mark.parametrize(
+    "via_kwargs", [False, True], ids=["positional", "kernel_kwargs"]
+)
+def test_nki_wrap_beta3_scalar_not_an_operand(via_kwargs):
+    """A non-tensor arg is compiled in, not passed as a custom-call operand.
+
+    Forwarding it as an operand would shift every later operand and make the
+    kernel read the wrong buffers.
+    """
+    a = np.random.rand(128, 512).astype(np.float32)
+
+    if via_kwargs:
+        nki_op = wrap_nki_kernel(
+            _beta3_scaled_kernel, [a], kernel_kwargs={"scale": 3.0},
+            is_nki_beta_3_version=True, platform_target="trn2",
+        )
+    else:
+        nki_op = wrap_nki_kernel(
+            _beta3_scaled_kernel, [a, 3.0],
+            is_nki_beta_3_version=True, platform_target="trn2",
+        )
+
+    # `scale` is not a device input, so the op takes only the one tensor.
+    assert nki_op._beta3_device_input_names == ["a_input"]
+    assert nki_op._beta3_constant_names == ["scale"]
+
+    traced = NKIPyKernel.trace(lambda x: nki_op(x), backend="hlo")
+    traced.specialize(a)
+
+
+@pytest.mark.skipif(
+    not BETA3_NKI_AVAILABLE, reason="Beta 3 NKI frontend (nki >= 0.4) not available"
+)
+@pytest.mark.parametrize(
+    "via_kwargs", [False, True], ids=["positional", "kernel_kwargs"]
+)
+def test_nki_wrap_beta3_scalar_mid_signature(via_kwargs):
+    """A constant in the MIDDLE of the signature still binds to the right param."""
+    a = np.random.rand(128, 512).astype(np.float32)
+    b = np.random.rand(128, 512).astype(np.float32)
+
+    if via_kwargs:
+        # kernel_kwargs fills `scale` by name, so the operands are just the tensors.
+        nki_op = wrap_nki_kernel(
+            _beta3_mid_scalar_kernel, [a, b], kernel_kwargs={"scale": 2.0},
+            is_nki_beta_3_version=True, platform_target="trn2",
+        )
+    else:
+        nki_op = wrap_nki_kernel(
+            _beta3_mid_scalar_kernel, [a, 2.0, b],
+            is_nki_beta_3_version=True, platform_target="trn2",
+        )
+
+    assert nki_op._beta3_device_input_names == ["a_input", "b_input"]
+
+    traced = NKIPyKernel.trace(lambda x, y: nki_op(x, y), backend="hlo")
+    traced.specialize(a, b)
+
+
+@pytest.mark.skipif(
+    not BETA3_NKI_AVAILABLE, reason="Beta 3 NKI frontend (nki >= 0.4) not available"
+)
+def test_nki_wrap_beta3_operand_mismatch_raises():
+    """A wrong operand count fails loudly instead of reaching the backend.
+
+    Without the check this surfaces from neuronx-cc as an opaque
+    "Unrecognized DRAM input location", or is silently miscompiled.
+    """
+    a = np.random.rand(128, 512).astype(np.float32)
+    nki_op = wrap_nki_kernel(
+        _beta3_scaled_kernel, [a, 3.0],
+        is_nki_beta_3_version=True, platform_target="trn2",
+    )
+
+    with pytest.raises(ValueError, match="expects 1 tensor operand"):
+        traced = NKIPyKernel.trace(lambda x, y: nki_op(x, y), backend="hlo")
+        traced.specialize(a, a)
+
+    # A constant passed at CALL time used to be silently ignored in favour of the
+    # compiled-in value; it is now rejected.
+    with pytest.raises(ValueError):
+        traced = NKIPyKernel.trace(lambda x: nki_op(x, 9.0), backend="hlo")
+        traced.specialize(a)
+
+
+@pytest.mark.skipif(
+    not BETA3_NKI_AVAILABLE, reason="Beta 3 NKI frontend (nki >= 0.4) not available"
+)
+def test_nki_wrap_beta3_kernel_kwargs_validated():
+    """kernel_kwargs must name real parameters, and is beta-3 only."""
+    a = np.random.rand(128, 512).astype(np.float32)
+
+    with pytest.raises(ValueError, match="not.*parameters"):
+        wrap_nki_kernel(
+            _beta3_scaled_kernel, [a], kernel_kwargs={"nope": 1.0},
+            is_nki_beta_3_version=True, platform_target="trn2",
+        )
+
+    with pytest.raises(ValueError, match="only supported by the beta 3"):
+        wrap_nki_kernel(
+            _beta3_scaled_kernel, [a], kernel_kwargs={"scale": 1.0},
+            platform_target="trn2",
+        )
+
+
+@pytest.mark.skipif(
+    not BETA3_NKI_AVAILABLE, reason="Beta 3 NKI frontend (nki >= 0.4) not available"
+)
+@pytest.mark.skipif(
+    not NEURON_AVAILABLE,
+    reason="Hardware required - Beta 3 frontend does not support CPU execution",
+)
+@pytest.mark.parametrize("scale", [1.0, 3.0])
+def test_nki_wrap_beta3_scalar_applied_on_device(scale):
+    """The compiled-in constant is the one the device actually uses."""
+    a = np.random.rand(128, 512).astype(np.float32)
+
+    nki_op = wrap_nki_kernel(
+        _beta3_scaled_kernel, [a], kernel_kwargs={"scale": scale},
+        is_nki_beta_3_version=True,
+    )
+
+    out = on_device_test(lambda x: nki_op(x), "hlo", a)
+    baremetal_assert_allclose(a * scale, out)
+
+
+# ---------------------------------------------------------------------------
+# Beta 3 kernel SIGNATURE SHAPES
+#
+# wrap_nki_kernel must not constrain how a kernel AUTHOR writes their signature.
+# Every kernel below computes the same thing -- ``a * c + b`` -- so a mis-binding
+# shows up as a wrong number rather than passing silently. Each is exercised both
+# with the constant supplied positionally in ``operands`` and by name via
+# ``kernel_kwargs``.
+#
+# Not covered, because NKI itself rejects it: keyword-ONLY parameters (``*``).
+# NKI's compiled parser frontend emits "keyword-only arguments are not supported
+# in NKI" followed by "unbound variable", independently of nkipy -- see
+# test_nki_beta3_keyword_only_unsupported_upstream.
+# ---------------------------------------------------------------------------
+
+# a=2, b=3, c=5  ->  2 * 5 + 3 = 13
+_SIG_A_VAL, _SIG_B_VAL, _SIG_C_VAL = 2.0, 3.0, 5.0
+_SIG_EXPECTED = _SIG_A_VAL * _SIG_C_VAL + _SIG_B_VAL
+
+
+if BETA3_NKI_AVAILABLE:
+
+    def _beta3_scale_add_body(a, b, c):
+        """out = a * c + b, in one scalar_tensor_tensor."""
+        a_tile = nl_beta3.load(a[:, :])
+        b_tile = nl_beta3.load(b[:, :])
+        out_tile = nl_beta3.ndarray(
+            a_tile.shape, dtype=a_tile.dtype, buffer=nl_beta3.sbuf
+        )
+        nisa_beta3.scalar_tensor_tensor(
+            dst=out_tile, data=a_tile,
+            op0=nl_beta3.multiply, operand0=c,
+            op1=nl_beta3.add, operand1=b_tile,
+        )
+        output = nl_beta3.ndarray(a.shape, dtype=a.dtype, buffer=nl_beta3.shared_hbm)
+        nl_beta3.store(output[:, :], value=out_tile)
+        return output
+
+    @nki_beta3.jit
+    def _sig_all_positional(a, b, c):
+        return _beta3_scale_add_body(a, b, c)
+
+    @nki_beta3.jit
+    def _sig_scalar_default(a, b, c=10.0):
+        return _beta3_scale_add_body(a, b, c)
+
+    @nki_beta3.jit
+    def _sig_tensor_and_scalar_default(a, b=None, c=10.0):
+        return _beta3_scale_add_body(a, b, c)
+
+    @nki_beta3.jit
+    def _sig_scalar_before_tensor_default(a, c, b=None):
+        return _beta3_scale_add_body(a, b, c)
+
+    @nki_beta3.jit
+    def _sig_scalar_default_before_tensor_default(a, c=10.0, b=None):
+        return _beta3_scale_add_body(a, b, c)
+
+    @nki_beta3.jit
+    def _sig_all_defaulted(a=None, b=None, c=10.0):
+        return _beta3_scale_add_body(a, b, c)
+
+    @nki_beta3.jit
+    def _sig_keyword_only_scalar(a, b, *, c):
+        """NKI does not support keyword-only params; used as a negative test."""
+        return _beta3_scale_add_body(a, b, c)
+
+
+# (kernel, positional operand order) -- `A`/`B` are tensors, `C` the constant.
+_SIG_CASES = {
+    "all_positional": ("_sig_all_positional", "ABC"),
+    "scalar_default": ("_sig_scalar_default", "ABC"),
+    "tensor_and_scalar_default": ("_sig_tensor_and_scalar_default", "ABC"),
+    "scalar_before_tensor_default": ("_sig_scalar_before_tensor_default", "ACB"),
+    "scalar_default_before_tensor_default": (
+        "_sig_scalar_default_before_tensor_default", "ACB",
+    ),
+    "all_defaulted": ("_sig_all_defaulted", "ABC"),
+}
+
+
+def _sig_operands(order, a, b, c):
+    """Build the positional operand list for a signature's parameter order."""
+    return [{"A": a, "B": b, "C": c}[ch] for ch in order]
+
+
+@pytest.mark.skipif(
+    not BETA3_NKI_AVAILABLE, reason="Beta 3 NKI frontend (nki >= 0.4) not available"
+)
+@pytest.mark.parametrize("case", sorted(_SIG_CASES))
+@pytest.mark.parametrize(
+    "via_kwargs", [False, True], ids=["positional", "kernel_kwargs"]
+)
+def test_nki_wrap_beta3_signature_shapes(case, via_kwargs):
+    """Any mix of positional/defaulted tensor and scalar params binds correctly.
+
+    In every shape the two tensors are the only device inputs, in signature
+    order -- the scalar never becomes an operand no matter where it sits.
+    """
+    kernel_name, order = _SIG_CASES[case]
+    kernel = globals()[kernel_name]
+    a = np.full((128, 512), _SIG_A_VAL, dtype=np.float32)
+    b = np.full((128, 512), _SIG_B_VAL, dtype=np.float32)
+
+    if via_kwargs:
+        # Only the tensors are positional; the scalar is bound by name. Note the
+        # operand list is [a, b] for EVERY shape -- naming `c` removes it from the
+        # positional sequence, so the author's parameter order stops mattering.
+        nki_op = wrap_nki_kernel(
+            kernel, [a, b], kernel_kwargs={"c": _SIG_C_VAL},
+            is_nki_beta_3_version=True, platform_target="trn2",
+        )
+    else:
+        nki_op = wrap_nki_kernel(
+            kernel, _sig_operands(order, a, b, _SIG_C_VAL),
+            is_nki_beta_3_version=True, platform_target="trn2",
+        )
+
+    # The scalar is a trace-time constant, so `a` and `b` are the only operands,
+    # always in signature order regardless of where `c` sits.
+    assert nki_op._beta3_device_input_names == ["a", "b"]
+    assert nki_op._beta3_constant_names == ["c"]
+
+    traced = NKIPyKernel.trace(lambda x, y: nki_op(x, y), backend="hlo")
+    traced.specialize(a, b)
+
+
+@pytest.mark.skipif(
+    not BETA3_NKI_AVAILABLE, reason="Beta 3 NKI frontend (nki >= 0.4) not available"
+)
+@pytest.mark.parametrize("case", sorted(_SIG_CASES))
+def test_nki_wrap_beta3_signature_shapes_tensor_by_name(case):
+    """A TENSOR may also be bound by name, mixed with positional operands."""
+    kernel_name, _ = _SIG_CASES[case]
+    kernel = globals()[kernel_name]
+    a = np.full((128, 512), _SIG_A_VAL, dtype=np.float32)
+    b = np.full((128, 512), _SIG_B_VAL, dtype=np.float32)
+
+    nki_op = wrap_nki_kernel(
+        kernel, [a], kernel_kwargs={"b": b, "c": _SIG_C_VAL},
+        is_nki_beta_3_version=True, platform_target="trn2",
+    )
+
+    # `b` came from kernel_kwargs but is still a device input, in signature order.
+    assert nki_op._beta3_device_input_names == ["a", "b"]
+
+    traced = NKIPyKernel.trace(lambda x, y: nki_op(x, y), backend="hlo")
+    traced.specialize(a, b)
+
+
+@pytest.mark.skipif(
+    not BETA3_NKI_AVAILABLE, reason="Beta 3 NKI frontend (nki >= 0.4) not available"
+)
+@pytest.mark.skipif(
+    not NEURON_AVAILABLE,
+    reason="Hardware required - Beta 3 frontend does not support CPU execution",
+)
+@pytest.mark.parametrize("case", sorted(_SIG_CASES))
+@pytest.mark.parametrize(
+    "via_kwargs", [False, True], ids=["positional", "kernel_kwargs"]
+)
+def test_nki_wrap_beta3_signature_shapes_on_device(case, via_kwargs):
+    """Every signature shape computes a * c + b correctly on hardware.
+
+    A mis-bound operand or a constant leaking into the operand list yields a
+    wrong number here rather than an opaque compile failure.
+    """
+    kernel_name, order = _SIG_CASES[case]
+    kernel = globals()[kernel_name]
+    a = np.full((128, 512), _SIG_A_VAL, dtype=np.float32)
+    b = np.full((128, 512), _SIG_B_VAL, dtype=np.float32)
+
+    if via_kwargs:
+        nki_op = wrap_nki_kernel(
+            kernel, [a, b], kernel_kwargs={"c": _SIG_C_VAL},
+            is_nki_beta_3_version=True,
+        )
+    else:
+        nki_op = wrap_nki_kernel(
+            kernel, _sig_operands(order, a, b, _SIG_C_VAL),
+            is_nki_beta_3_version=True,
+        )
+
+    out = on_device_test(lambda x, y: nki_op(x, y), "hlo", a, b)
+    baremetal_assert_allclose(np.full_like(a, _SIG_EXPECTED), out)
+
+
+@pytest.mark.skipif(
+    not BETA3_NKI_AVAILABLE, reason="Beta 3 NKI frontend (nki >= 0.4) not available"
+)
+def test_nki_beta3_keyword_only_unsupported_upstream():
+    """Keyword-only params (``*``) are rejected by NKI itself, not by nkipy.
+
+    Documents the one signature shape a kernel author cannot use. The same
+    failure occurs through NKI's own execution path with nkipy uninvolved, so
+    there is nothing for wrap_nki_kernel to fix; this test pins the behaviour so
+    we notice if a future nki release starts supporting it.
+    """
+    a = np.full((128, 512), _SIG_A_VAL, dtype=np.float32)
+    b = np.full((128, 512), _SIG_B_VAL, dtype=np.float32)
+
+    with pytest.raises(RuntimeError, match="failed to compile NKI kernel"):
+        wrap_nki_kernel(
+            _sig_keyword_only_scalar, [a, b], kernel_kwargs={"c": _SIG_C_VAL},
+            is_nki_beta_3_version=True, platform_target="trn2",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Beta 3 OPTIONAL MUTABLE OUTPUT tensor
+#
+# Combines a defaulted keyword tensor with output aliasing:
+#
+#     def add_kernel(a, b, c=10.0, out=None):
+#         if out is None: <allocate>
+#         out[...] = a * c + b
+#         return out
+#
+# One source, two compiled shapes, driven purely by whether `out` is supplied:
+#   out=None      -> `out` is a trace-time constant; device inputs [a, b]; no alias
+#   out=<ndarray> -> `out` is a device input;         device inputs [a, b, out];
+#                    alias {2: 0}
+#
+# The alias map is {input_idx: output_idx} indexed over the DEVICE-INPUT list, so
+# it must skip the `c` constant: `out` is index 2, not 3. An off-by-one here would
+# alias the wrong buffer, so these tests pin the index explicitly.
+# ---------------------------------------------------------------------------
+
+
+if BETA3_NKI_AVAILABLE:
+
+    @nki_beta3.jit
+    def _sig_optional_out(a, b, c=10.0, out=None):
+        """out = a * c + b, writing into `out` when the caller supplies one."""
+        a_tile = nl_beta3.load(a[:, :])
+        b_tile = nl_beta3.load(b[:, :])
+        out_tile = nl_beta3.ndarray(
+            a_tile.shape, dtype=a_tile.dtype, buffer=nl_beta3.sbuf
+        )
+        nisa_beta3.scalar_tensor_tensor(
+            dst=out_tile, data=a_tile,
+            op0=nl_beta3.multiply, operand0=c,
+            op1=nl_beta3.add, operand1=b_tile,
+        )
+        if out is None:
+            out = nl_beta3.ndarray(
+                a.shape, dtype=a.dtype, buffer=nl_beta3.shared_hbm
+            )
+        nl_beta3.store(out[:, :], value=out_tile)
+        return out
+
+
+@pytest.mark.skipif(
+    not BETA3_NKI_AVAILABLE, reason="Beta 3 NKI frontend (nki >= 0.4) not available"
+)
+def test_nki_wrap_beta3_optional_out_omitted():
+    """`out` omitted: it is a trace-time constant and the kernel allocates."""
+    a = np.full((128, 512), _SIG_A_VAL, dtype=np.float32)
+    b = np.full((128, 512), _SIG_B_VAL, dtype=np.float32)
+
+    nki_op = wrap_nki_kernel(
+        _sig_optional_out, [a, b], kernel_kwargs={"c": _SIG_C_VAL},
+        is_nki_beta_3_version=True, platform_target="trn2",
+    )
+
+    assert nki_op._beta3_device_input_names == ["a", "b"]
+    # Both `c` and the unsupplied `out` (None) are non-tensors.
+    assert nki_op._beta3_constant_names == ["c", "out"]
+    assert nki_op._beta3_framework_config.operand_output_aliases == {}
+
+    traced = NKIPyKernel.trace(lambda x, y: nki_op(x, y), backend="hlo")
+    traced.specialize(a, b)
+
+
+@pytest.mark.skipif(
+    not BETA3_NKI_AVAILABLE, reason="Beta 3 NKI frontend (nki >= 0.4) not available"
+)
+@pytest.mark.parametrize(
+    "via_kwargs", [False, True], ids=["positional", "kernel_kwargs"]
+)
+def test_nki_wrap_beta3_optional_out_supplied_aliases(via_kwargs):
+    """`out` supplied: it becomes a third device input, aliased to output 0.
+
+    The alias index must be 2 (position in the device-input list), NOT 3 (its
+    position in the signature) -- the `c` constant does not occupy an operand.
+    """
+    a = np.full((128, 512), _SIG_A_VAL, dtype=np.float32)
+    b = np.full((128, 512), _SIG_B_VAL, dtype=np.float32)
+    out = np.zeros((128, 512), dtype=np.float32)
+
+    if via_kwargs:
+        nki_op = wrap_nki_kernel(
+            _sig_optional_out, [a, b],
+            kernel_kwargs={"c": _SIG_C_VAL, "out": out},
+            is_nki_beta_3_version=True, platform_target="trn2",
+        )
+    else:
+        # Positionally, `c` must be given to reach `out`.
+        nki_op = wrap_nki_kernel(
+            _sig_optional_out, [a, b, _SIG_C_VAL, out],
+            is_nki_beta_3_version=True, platform_target="trn2",
+        )
+
+    assert nki_op._beta3_device_input_names == ["a", "b", "out"]
+    assert nki_op._beta3_constant_names == ["c"]
+    assert nki_op._beta3_framework_config.operand_output_aliases == {2: 0}
+
+    traced = NKIPyKernel.trace(lambda x, y, o: nki_op(x, y, o), backend="hlo")
+    traced.specialize(a, b, out)
+
+
+@pytest.mark.skipif(
+    not BETA3_NKI_AVAILABLE, reason="Beta 3 NKI frontend (nki >= 0.4) not available"
+)
+@pytest.mark.skipif(
+    not NEURON_AVAILABLE,
+    reason="Hardware required - Beta 3 frontend does not support CPU execution",
+)
+def test_nki_wrap_beta3_optional_out_omitted_on_device():
+    """The allocating variant returns a * c + b on hardware."""
+    a = np.full((128, 512), _SIG_A_VAL, dtype=np.float32)
+    b = np.full((128, 512), _SIG_B_VAL, dtype=np.float32)
+
+    nki_op = wrap_nki_kernel(
+        _sig_optional_out, [a, b], kernel_kwargs={"c": _SIG_C_VAL},
+        is_nki_beta_3_version=True,
+    )
+
+    out = on_device_test(lambda x, y: nki_op(x, y), "hlo", a, b)
+    baremetal_assert_allclose(np.full_like(a, _SIG_EXPECTED), out)
+
+
+@pytest.mark.skipif(
+    not BETA3_NKI_AVAILABLE, reason="Beta 3 NKI frontend (nki >= 0.4) not available"
+)
+@pytest.mark.skipif(
+    not NEURON_AVAILABLE,
+    reason="Hardware required - Beta 3 frontend does not support CPU execution",
+)
+def test_nki_wrap_beta3_optional_out_aliased_on_device():
+    """The caller's `out` buffer is mutated IN PLACE on hardware.
+
+    Reads back through the caller's own device tensor, so an alias pointing at
+    the wrong operand leaves it at its initial 0.0 and fails here.
+    """
+    from nkipy.runtime import DeviceKernel, DeviceTensor
+
+    a = np.full((128, 512), _SIG_A_VAL, dtype=np.float32)
+    b = np.full((128, 512), _SIG_B_VAL, dtype=np.float32)
+    out = np.zeros((128, 512), dtype=np.float32)
+
+    nki_op = wrap_nki_kernel(
+        _sig_optional_out, [a, b], kernel_kwargs={"c": _SIG_C_VAL, "out": out},
+        is_nki_beta_3_version=True,
+    )
+
+    def kernel_fn(a, b, out):
+        return nki_op(a, b, out)
+
+    traced = NKIPyKernel.trace(kernel_fn, backend="hlo")
+    device_kernel = DeviceKernel.compile_and_load(
+        traced, a, b, out, use_cached_if_exists=False
+    )
+
+    t_a = DeviceTensor.from_numpy(a)
+    t_b = DeviceTensor.from_numpy(b)
+    t_out = DeviceTensor.from_numpy(out)
+    device_kernel(
+        inputs={"a": t_a, "b": t_b, "out.must_alias_input": t_out},
+        outputs={"out": t_out},
+    )
+
+    baremetal_assert_allclose(t_out.numpy(), np.full_like(a, _SIG_EXPECTED))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
`wrap_nki_kernel` mishandled non-tensor arguments to NKI **beta 3** kernels. NKI's beta 3 frontend splits kernel arguments into *device inputs* (ndarrays → HBM operands) and *constants* (scalars, tuples, ...) that it specializes into the compiled kernel. nkipy ignored that split: it zipped operands onto parameter names positionally, then forwarded every ndarray-or-scalar as a custom-call operand.

This adds `kernel_kwargs=` for binding parameters by name, drops constants from the emitted operand list, and validates operand counts. Follow-up to #76.

Kernel authors can now write any of these signatures, and callers may supply the constant positionally or by name:
```python
@nki.jit
def k(a, b, c):                 # all positional
@nki.jit
def k(a, b, c=10.0):            # scalar defaulted
@nki.jit
def k(a, c, b=None):            # constant BEFORE a defaulted tensor
@nki.jit
def k(a, b, c=10.0, out=None):  # optional mutable output (aliased when supplied)

# `c` is a trace-time constant, so it is bound at wrap time, not at call time:
op = wrap_nki_kernel(k, [a, b], kernel_kwargs={"c": 5.0}, is_nki_beta_3_version=True)
op(a, b)                        # tensors only -- `c` is compiled in

# equivalently, positionally (must fill preceding params to reach later ones):
op = wrap_nki_kernel(k, [a, 5.0, b], is_nki_beta_3_version=True)   # for k(a, c, b=None)

```

## Changes
`nkipy/src/nkipy/core/nki_op.py`:
- Add `_beta3_is_device_input()`, mirroring NKI's own `_classify_kernel_args` classification. Non-tensors are dropped from the operand list on both the `wrap_nki_kernel` and direct `@nki.jit` paths.
- `_compile_beta3` binds operands to the signature **by name** (`sig.bind_partial` + `apply_defaults`) instead of positional zipping.
- Add `kernel_kwargs=` to `wrap_nki_kernel` / `NKICustomOp`; unknown parameter names and use with a non-beta-3 frontend raise `ValueError`. Beta 3 only — the legacy and beta 2 paths are unchanged.
- Add `_check_beta3_operands()`, raising a descriptive `ValueError` on a call-time operand-count mismatch, or when a non-tensor is passed at call time (where it can only be silently ignored, the value having already been compiled in).

No behaviour change for all-tensor kernels, which is every existing caller and test.

## New tests
13 test functions / 44 cases in `tests/unit/test_nki.py`. Each kernel computes`a * c + b` with `a=2, b=3, c=5`, so a mis-binding yields a wrong number rather than passing silently.
- **Constants**: compiled in rather than passed as operands (asserted via the recorded device-input/constant name lists); positional and `kernel_kwargs`, including mid-signature; the compiled-in value is what the device uses; bad operand counts, call-time constants, and invalid `kernel_kwargs` all raise.
- **Signature shapes**: 6 parameter layouts an author may write — all positional, scalar defaulted, tensor+scalar defaulted, scalar (positional or defaulted) before a defaulted tensor, all defaulted — each exercised positionally and via `kernel_kwargs`, at trace time and on device. Tensors may also be bound by name and mixed with positional operands.
- **Optional mutable output** (`def add_kernel(a, b, c=10.0, out=None)`), covering keyword args combined with output aliasing. One source, two compiled shapes: omitting `out` makes it a constant and the kernel allocates; supplying it makes it a third device input aliased to output 0. The alias index is asserted explicitly — `operand_output_aliases` is `{input_idx: output_idx}` over the *device-input* list, so `out` is index **2**, not its signature position 3. The on-device test reads back through the caller's own `DeviceTensor`, so a misdirected alias fails.
