### PR TITLE
perf(runtime): disable NRT per-execution barrier by default

### DIFF
--- a/nkipy/src/nkipy/runtime/__init__.py
+++ b/nkipy/src/nkipy/runtime/__init__.py
@@ -1,8 +1,30 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-from .decorators import baremetal_jit
-from .execute import baremetal_run_traced_kernel
-from .utils import is_neuron_compatible
+import os
+
+from nkipy.core.logger import get_logger
+
+# Disable the NRT per-execution collectives barrier by default: it adds fixed
+# host-side dispatch latency (~1.8x on batch=1 decode) and is a no-op for
+# non-collective kernels. Safe for single-rank and SPMD (nkipy's default); the
+# load-time barrier is kept. Only MPMD-with-collectives needs it on, to detect
+# ranks running mismatched graphs — see the guard in compile_and_load.
+# Must be set here at import: NRT reads it at nrt_init() (the first device op),
+# so setting it later is ignored. setdefault lets an explicit user override win.
+_BARRIER_ENV = "NEURON_RT_DISABLE_EXECUTION_BARRIER"
+if _BARRIER_ENV not in os.environ:
+    os.environ[_BARRIER_ENV] = "1"
+    get_logger().warning(
+        "nkipy set %s=1 (skips NRT per-execution collectives barrier for lower "
+        "dispatch latency; safe for single-rank/SPMD). For MPMD-with-collectives, "
+        "set it =0 before importing nkipy.",
+        _BARRIER_ENV,
+    )
+
+# Imports below intentionally follow the env setup above (must run before NRT init).
+from .decorators import baremetal_jit  # noqa: E402
+from .execute import baremetal_run_traced_kernel  # noqa: E402
+from .utils import is_neuron_compatible  # noqa: E402
 
 try:
     from .baremetal_executor import BaremetalExecutor, CompiledKernel

--- a/nkipy/src/nkipy/runtime/device_kernel.py
+++ b/nkipy/src/nkipy/runtime/device_kernel.py
@@ -172,6 +172,23 @@ class DeviceKernel(SpikeModel):
                 "and torch.distributed is not available for auto-detection"
             )
 
+        # MPMD-with-collectives is the one case where nkipy's default of disabling
+        # the NRT execution barrier (see nkipy/runtime/__init__.py) is unsafe: with
+        # per-rank-independent graphs, that barrier is the runtime's only mid-run
+        # detector of mismatched graphs across ranks. Warn so the user can re-enable.
+        if (
+            not is_spmd
+            and resolved_cc
+            and os.environ.get("NEURON_RT_DISABLE_EXECUTION_BARRIER") == "1"
+        ):
+            logger.warning(
+                "MPMD execution (is_spmd=False) with collectives while "
+                "NEURON_RT_DISABLE_EXECUTION_BARRIER=1: the NRT per-execution "
+                "barrier that detects mismatched graphs across ranks is disabled. "
+                "Set NEURON_RT_DISABLE_EXECUTION_BARRIER=0 before importing nkipy "
+                "to restore it."
+            )
+
         # Barrier only needed in SPMD mode (rank 0 compiled for everyone)
         if is_spmd and distributed:
             dist.barrier()


### PR DESCRIPTION
## Summary

Set `NEURON_RT_DISABLE_EXECUTION_BARRIER=1` by default at `nkipy.runtime` import time. On recent Neuron runtimes this per-execution **collectives** barrier adds a fixed host-side dispatch cost per `execute()` that dominates dispatch-bound workloads (e.g. batch=1 decode). Disabling the barrier is a large, free win for single-rank and SPMD execution.

The env var is set via `setdefault` (an explicit user override always wins) with a one-time warning log. It must be set at import because NRT reads it at `nrt_init()`, which fires on the first device op — setting it later has no effect.

## Benchmark data (gpt-oss-20b, TP4, trn2, n=200)

Barrier **disabled** (`=1`, this PR's default) vs **enabled** (`=0`, prior behavior). The speedup comes from **disabling** the barrier:

**Base model (end-to-end generation)**
| Config | Decode tok/s | TTFT |
|---|---|---|
| Barrier enabled (`=0`, old default) | 22.15 | 0.43 s |
| **Barrier disabled (`=1`, this PR)** | **40.96** | 0.41 s |
| | **1.85×** | unchanged |

**P-EAGLE speculative decoding (K=3, `--profile`)**
| Config | Decode tok/s | Accept len | verify ms/step | draft ms/step |
|---|---|---|---|---|
| Barrier enabled (`=0`, old default) | 33.27 | 3.07 | 70.9 | 15.0 |
| **Barrier disabled (`=1`, this PR)** | **43.60** | 3.07 | 50.7 | 14.7 |
| | **1.31×** | identical | −28% | unchanged |

The P-EAGLE gain is entirely in the 24-layer **verify** pass (65.0 → 45.9 ms/step); the drafter (single fused kernel/step, no per-layer collective) is unaffected — which is why its speedup is smaller than the base model's. Acceptance length is identical (3.07) and generated text is bit-identical (greedy verify stays deterministic), confirming correctness is preserved.

## Safety

Verified against the Neuron runtime source (`KaenaRuntime` `enc.cc`):
- The flag drops **only the per-execution barrier**; the **load-time barrier is always kept**.
- It is a **no-op for non-collective kernels** (single-rank / no CC), so it only affects distributed execution.
- **Safe for SPMD** (all ranks run the identical graph each step — the common distributed-inference case, and nkipy's default `is_spmd=True`).
- The **one unsafe case is MPMD-with-collectives** (`is_spmd=False` + `cc_enabled`), where this barrier is the runtime's only mid-run detector of ranks running mismatched graphs. `DeviceKernel.compile_and_load` now **warns** on that exact combination and tells the user to set `NEURON_RT_DISABLE_EXECUTION_BARRIER=0` (re-enable the barrier) before importing nkipy.

## Changes
- `nkipy/runtime/__init__.py`: set the env default (before NRT init) + one-time warning.
- `nkipy/runtime/device_kernel.py`: warn when MPMD-with-collectives runs with the barrier disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)