### PR TITLE
feat(runtime): non-blocking submit for DeviceKernel via SpikeAsync

### DIFF
--- a/examples/models/gpt_oss/gpt_oss.py
+++ b/examples/models/gpt_oss/gpt_oss.py
@@ -19,6 +19,15 @@ from utils import encode_prompt, print_log
 BUILD_DIR = os.path.abspath("./build")
 USE_NKI_RMSNORM = True
 
+# Decode is host-dispatch-bound at batch=1: the blocking DeviceKernel.__call__
+# stalls the host on every one of the ~25 kernels per token, so dispatch of
+# kernel N+1 can't overlap device execution of kernel N. GPT_OSS_ASYNC=1 submits
+# the tkg layer stack + sampling non-blocking (submit/wait) to reclaim that
+# overlap. GPT_OSS_ASYNC_WINDOW caps in-flight ops so the finite-depth compute
+# queue doesn't overflow (NRT_QUEUE_FULL).
+ASYNC_DECODE = os.environ.get("GPT_OSS_ASYNC", "0") == "1"
+ASYNC_WINDOW = int(os.environ.get("GPT_OSS_ASYNC_WINDOW", "4"))
+
 # weight names carried per layer (everything except the kv cache)
 _LAYER_WEIGHT_KEYS = [
     "qkv_weight",
@@ -171,7 +180,8 @@ class GptOssModel:
             f"--> Finished Kernel Compilation and Loading in {time.time() - t:.2f}s"
         )
 
-    def _run_layer(self, phase, i, hidden_states, start_pos):
+    def _layer_io(self, phase, i, hidden_states, start_pos):
+        """Build (kernel, inputs, outputs) for one transformer layer."""
         lt = self.layer_tensors[i]
         kernel = self.kernel_layer[(phase, self.config.is_sliding(i))]
         inputs = {key: lt[key] for key in _LAYER_WEIGHT_KEYS}
@@ -180,14 +190,16 @@ class GptOssModel:
         inputs["cache_v.must_alias_input"] = lt["cache_v"]
         if phase == "tkg":
             inputs["start_pos"] = start_pos
-        kernel(
-            inputs=inputs,
-            outputs={
-                "output0": hidden_states,
-                "cache_k": lt["cache_k"],
-                "cache_v": lt["cache_v"],
-            },
-        )
+        outputs = {
+            "output0": hidden_states,
+            "cache_k": lt["cache_k"],
+            "cache_v": lt["cache_v"],
+        }
+        return kernel, inputs, outputs
+
+    def _run_layer(self, phase, i, hidden_states, start_pos):
+        kernel, inputs, outputs = self._layer_io(phase, i, hidden_states, start_pos)
+        kernel(inputs=inputs, outputs=outputs)
 
     def run_prefill(self, input_ids, capture_aux=False):
         """Run the context-encoding (prefill) layer stack.
@@ -221,6 +233,41 @@ class GptOssModel:
         for i in range(self.config.num_layers):
             self._run_layer("tkg", i, hidden_states, start_pos)
 
+    def _sampling_io(self, kernel, hidden_states, next_id):
+        """Build (kernel, inputs, outputs) for a greedy-sampling head."""
+        inputs = {
+            "h": hidden_states,
+            "norm_weight": self.norm_weight,
+            "lm_head_weight": self.lm_head_weight,
+        }
+        return kernel, inputs, {"output0": next_id}
+
+    def _decode_step_async(self, hidden_states, start_pos, next_id):
+        """Run one tkg step (layers + sampling) via non-blocking submit/wait.
+
+        Layers write hidden_states in place and share the runtime's FIFO compute
+        channel, so submitting without waiting preserves ordering/data deps while
+        overlapping host dispatch with device execution. The window bounds in-flight
+        ops (finite queue depth). Draining every future in FIFO order -- not just
+        the last -- surfaces a failed submission from its own ``.wait()`` instead
+        of hanging behind it, and leaves no exception unretrieved.
+        """
+        futs = []
+
+        def _submit(kernel, inputs, outputs):
+            if len(futs) >= ASYNC_WINDOW:
+                futs.pop(0).wait()
+            futs.append(kernel.submit(inputs, outputs))
+
+        for i in range(self.config.num_layers):
+            _submit(*self._layer_io("tkg", i, hidden_states, start_pos))
+        _submit(*self._sampling_io(self.kernel_tkg_greedy_sampling,
+                                   hidden_states, next_id))
+        # Wait in submission (FIFO) order: each .wait() retrieves that op's
+        # result/exception; the last completing implies the whole step is done.
+        for fut in futs:
+            fut.wait()
+
     def generate(self, input_ids):
         """Run inference and generate tokens."""
         hidden_states, _ = self.run_prefill(input_ids, capture_aux=False)
@@ -252,16 +299,14 @@ class GptOssModel:
             t_start_pos.write_from_numpy(np.array([pos], dtype=np.int32))
             hidden_states.write_from_torch(self.tok_embedding[next_id_torch])
 
-            self._run_tkg_layers(hidden_states, t_start_pos)
-
-            self.kernel_tkg_greedy_sampling(
-                inputs={
-                    "h": hidden_states,
-                    "norm_weight": self.norm_weight,
-                    "lm_head_weight": self.lm_head_weight,
-                },
-                outputs={"output0": next_id},
-            )
+            if ASYNC_DECODE:
+                self._decode_step_async(hidden_states, t_start_pos, next_id)
+            else:
+                self._run_tkg_layers(hidden_states, t_start_pos)
+                kernel, inputs, outputs = self._sampling_io(
+                    self.kernel_tkg_greedy_sampling, hidden_states, next_id
+                )
+                kernel(inputs=inputs, outputs=outputs)
 
             next_id_torch = next_id.torch().reshape(B, 1).to(dtype=torch.int)
             yield next_id_torch

--- a/nkipy/src/nkipy/runtime/device_kernel.py
+++ b/nkipy/src/nkipy/runtime/device_kernel.py
@@ -12,7 +12,7 @@ from nkipy.core.logger import get_logger
 from nkipy.core.trace import NKIPyKernel
 from nkipy.runtime import device_tensor
 from nkipy.runtime.device_tensor import DeviceTensor
-from spike import SpikeModel
+from spike import SpikeModel, get_spike_async_singleton
 
 if device_tensor._TORCH_ENABLED:
     import torch.distributed as dist
@@ -47,6 +47,37 @@ class DeviceKernel(SpikeModel):
 
     def __init__(self, model_ref, name, neff_path):
         super().__init__(model_ref, name, neff_path)
+
+    def submit(self, inputs, outputs):
+        """Submit this kernel without blocking; return a future.
+
+        Unlike :meth:`__call__` (which blocks), this enqueues the kernel on the
+        runtime's FIFO compute channel via ``SpikeAsync`` and returns immediately,
+        so the host can submit the next kernel while this one runs. FIFO ordering
+        preserves data dependencies between successive submissions.
+
+        Call ``.wait()`` on the returned future before reading outputs back;
+        ``inputs``/``outputs`` must stay alive until then. The compute queue has
+        finite depth, so cap in-flight submissions by waiting on older futures.
+
+        Args:
+            inputs: Dict[str, DeviceTensor] keyed by NEFF input name.
+            outputs: Dict[str, DeviceTensor] keyed by NEFF output name.
+
+        Returns:
+            spike.SpikeAsyncFuture: resolves when this submission completes.
+        """
+        # Validate up front (as __call__ does) so name/shape/dtype/core mismatches
+        # fail here, not later as an opaque NRT error out of .wait().
+        self._validate_io(inputs, outputs)
+
+        sa = get_spike_async_singleton()
+        in_set = sa.create_tensor_set({k: v.tensor_ref for k, v in inputs.items()})
+        out_set = sa.create_tensor_set({k: v.tensor_ref for k, v in outputs.items()})
+        # Dep-free fast path: FIFO channel already orders successive submissions,
+        # so no stream/deps (those would serialize submission on completion and
+        # defeat host/device overlap).
+        return sa.execute(self.model_ref, in_set, out_set)
 
     @classmethod
     def compile_and_load(

--- a/spike/src/spike/__init__.py
+++ b/spike/src/spike/__init__.py
@@ -13,9 +13,14 @@ from ._spike import (
     TensorMetadata,
 )
 from .profiler_adapter import SpikeProfiler
-from .spike_async import SpikeAsync, SpikeStream, NonBlockResult
+from .spike_async import NonBlockResult, SpikeAsync, SpikeStream
 from .spike_model import BenchmarkResult, SpikeModel
-from .spike_singleton import configure, get_spike_singleton, reset
+from .spike_singleton import (
+    configure,
+    get_spike_async_singleton,
+    get_spike_singleton,
+    reset,
+)
 from .spike_tensor import SpikeTensor
 
 __all__ = [
@@ -24,6 +29,7 @@ __all__ = [
     "SpikeProfiler",
     "SpikeAsync",
     "SpikeStream",
+    "get_spike_async_singleton",
     "Spike",
     "configure",
     "reset",

--- a/spike/src/spike/spike_async.py
+++ b/spike/src/spike/spike_async.py
@@ -124,8 +124,11 @@ class SpikeAsyncEventLoop(asyncio.BaseEventLoop):
 class SpikeAsync:
     """Async interface for Spike runtime."""
 
-    def __init__(self, verbose_level: int = 0) -> None:
-        self.spike: Spike = Spike(verbose_level=verbose_level)
+    def __init__(self, verbose_level: int = 0, spike: Spike | None = None) -> None:
+        # Wrap an existing Spike when given (e.g. the process singleton) so models
+        # loaded on it run here without a second NRT runtime; else build a fresh
+        # one (standalone use).
+        self.spike: Spike = spike if spike is not None else Spike(verbose_level=verbose_level)
 
         self._selector: SpikeAsyncSelector = SpikeAsyncSelector(self.spike)
         self._loop: SpikeAsyncEventLoop = SpikeAsyncEventLoop(self._selector)

--- a/spike/src/spike/spike_singleton.py
+++ b/spike/src/spike/spike_singleton.py
@@ -4,7 +4,8 @@ This module provides the singleton pattern for the Spike runtime, ensuring
 only one NRT runtime instance exists at a time.
 
 Thread Safety:
-    - `get_spike_singleton()` and `reset()` are thread-safe (protected by lock)
+    - `get_spike_singleton()`, `get_spike_async_singleton()`, and `reset()` are
+      thread-safe (protected by lock)
     - `configure()` checks runtime state under lock, but env var setting is not locked
       (if multiple threads race to configure, last one wins - user's responsibility)
 """
@@ -21,6 +22,9 @@ from .logger import get_logger
 logger = get_logger()
 
 _runtime: Optional[_Spike] = None
+# Non-blocking view of the singleton: a SpikeAsync wrapping the _runtime Spike.
+# Lazily created on first async use; only async callers pay for the event loop.
+_async_runtime = None
 _lock = threading.Lock()
 
 
@@ -105,7 +109,7 @@ def reset() -> None:
         >>> spike.configure(visible_cores=[2, 3])  # Optional: change cores
         >>> tensor2 = SpikeTensor(...)  # Uses cores 2, 3
     """
-    global _runtime
+    global _runtime, _async_runtime
 
     with _lock:
         if _runtime is not None:
@@ -117,6 +121,8 @@ def reset() -> None:
             )
             _runtime.close()
             _runtime = None
+            # Drop the async view too; it wraps the Spike we just closed.
+            _async_runtime = None
             logger.info("Spike Runtime closed")
 
 
@@ -147,12 +153,42 @@ def get_spike_singleton() -> _Spike:
         return _runtime
 
 
+def get_spike_async_singleton():
+    """Get the SpikeAsync view of the runtime singleton, created lazily.
+
+    Wraps the one process ``Spike`` (from :func:`get_spike_singleton`) so
+    models/tensors loaded blockingly can be submitted non-blockingly without a
+    second NRT runtime. Only async callers construct it (and its event loop);
+    reset by :func:`reset` along with the Spike it wraps. Thread-safe.
+
+    Returns:
+        spike.SpikeAsync: the process-wide async view.
+    """
+    global _async_runtime
+
+    if _async_runtime is not None:
+        return _async_runtime
+
+    # Resolve (and lazily build) the Spike singleton BEFORE taking _lock:
+    # get_spike_singleton() re-acquires _lock on its init path, and _lock is
+    # non-reentrant, so calling it while holding _lock self-deadlocks.
+    spike = get_spike_singleton()
+
+    with _lock:
+        if _async_runtime is None:
+            from .spike_async import SpikeAsync
+
+            _async_runtime = SpikeAsync(spike=spike)
+        return _async_runtime
+
+
 def _cleanup() -> None:
     """Cleanup function called at program exit."""
-    global _runtime
+    global _runtime, _async_runtime
     with _lock:
         runtime = _runtime
         _runtime = None
+        _async_runtime = None
     if runtime is not None:
         # Close NRT before Python starts tearing down nanobind module state.
         # Models and tensors retain a shared closed-state token and skip NRT

--- a/spike/tests/test_spike_async.py
+++ b/spike/tests/test_spike_async.py
@@ -51,9 +51,14 @@ def neff_path(request):
 
 @pytest.fixture(scope="module")
 def spike_async():
-    """Initialize SpikeAsync for testing."""
+    """Initialize a standalone SpikeAsync for testing."""
     from spike import SpikeAsync
 
+    # NRT allows one Spike per process, and the runtime singleton (a Spike, with
+    # a lazily-created SpikeAsync view over it) may already be up; tear it down
+    # first so this standalone instance can init cleanly even if a prior test in
+    # the same process brought the singleton up.
+    spike_reset()
     spike_async = SpikeAsync()
     yield spike_async
     spike_async.spike.close()

--- a/tests/unit/test_device_kernel_async.py
+++ b/tests/unit/test_device_kernel_async.py
@@ -1,0 +1,155 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for DeviceKernel.submit (non-blocking execute).
+
+submit() is a thin wrapper over the singleton-backed SpikeAsync: it validates
+I/O (like __call__), turns the DeviceTensor dicts into tensor sets, and returns
+SpikeAsync's future. The event-loop/poll machinery lives in SpikeAsync and is
+tested there; here we cover the wrapper glue with a fake SpikeAsync, so no Neuron
+hardware is needed. A device-gated round-trip at the bottom exercises the real
+path when hardware is present.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+import nkipy.runtime.device_kernel as dk
+from nkipy.runtime.device_kernel import DeviceKernel
+
+
+class _FakeFuture:
+    """Stand-in for SpikeAsyncFuture; records that .wait() was called."""
+
+    def __init__(self):
+        self.waited = False
+
+    def wait(self):
+        self.waited = True
+
+
+class FakeSpikeAsync:
+    """Minimal SpikeAsync stand-in: echoes tensor sets, records executes."""
+
+    def __init__(self):
+        self.executed = []  # list of (model, in_set, out_set)
+
+    def create_tensor_set(self, tensors):
+        return tensors
+
+    def execute(self, model, inputs, outputs):
+        self.executed.append((model, inputs, outputs))
+        return _FakeFuture()
+
+
+@pytest.fixture
+def fake_async():
+    """Patch the module's SpikeAsync accessor with a fake."""
+    fake = FakeSpikeAsync()
+    with patch.object(dk, "get_spike_async_singleton", return_value=fake):
+        yield fake
+
+
+# Tensor info the fake kernel advertises for its "a" input and "o" output; must
+# match the fake tensors below so _validate_io passes.
+_INFO = SimpleNamespace(shape=(1,), dtype=np.dtype("float32"), size=4)
+
+
+def _make_kernel():
+    """A DeviceKernel instance without touching hardware (bypass __init__)."""
+    k = DeviceKernel.__new__(DeviceKernel)
+    k.model_ref = SimpleNamespace(core_id=0)
+    k.name = "fake"
+    k.input_tensors_info = {"a": _INFO}
+    k.output_tensors_info = {"o": _INFO}
+    return k
+
+
+class _T:
+    """Tiny DeviceTensor stand-in with the attributes _validate_io checks."""
+
+    tensor_ref = SimpleNamespace(core_id=0)
+    shape = (1,)
+    dtype = np.dtype("float32")
+
+
+def _t():
+    return _T()
+
+
+def test_submit_returns_future_and_executes(fake_async):
+    """submit() builds tensor sets from tensor_refs and returns SpikeAsync's future."""
+    k = _make_kernel()
+    a, o = _t(), _t()
+    fut = k.submit(inputs={"a": a}, outputs={"o": o})
+
+    assert fut.waited is False  # non-blocking: not waited yet
+    assert len(fake_async.executed) == 1
+    model, in_set, out_set = fake_async.executed[0]
+    assert model is k.model_ref
+    # tensor sets are keyed by NEFF name -> the DeviceTensor's tensor_ref
+    assert in_set == {"a": a.tensor_ref}
+    assert out_set == {"o": o.tensor_ref}
+
+    fut.wait()
+    assert fut.waited is True
+
+
+def test_submit_validates_io(fake_async):
+    """Bad input names are rejected before anything is submitted (parity with __call__).
+
+    Without validation the mismatch would only surface later as an opaque NRT
+    failure, detached from the offending submission.
+    """
+    k = _make_kernel()
+    with pytest.raises(ValueError, match="Unknown input"):
+        k.submit(inputs={"wrong_name": _t()}, outputs={"o": _t()})
+    # Nothing was submitted.
+    assert fake_async.executed == []
+
+
+# --------------------------------------------------------------------------
+# Device round-trip: real submit + future.wait() on Neuron hardware.
+# --------------------------------------------------------------------------
+
+from nkipy.runtime import is_neuron_compatible  # noqa: E402
+
+
+@pytest.mark.skipif(
+    not is_neuron_compatible(),
+    reason="Need Neuron hardware for submit round-trip",
+)
+def test_submit_roundtrip_matches_sync():
+    """submit()+wait() yields the same output as the blocking __call__ path."""
+    from nkipy.runtime.device_tensor import DeviceTensor
+
+    def add_kernel(a, b):
+        return np.add(a, b)
+
+    a = np.random.randn(128, 128).astype(np.float32)
+    b = np.random.randn(128, 128).astype(np.float32)
+    da = DeviceTensor.from_numpy(a, "async_a")
+    db = DeviceTensor.from_numpy(b, "async_b")
+    out_async = DeviceTensor.from_numpy(np.empty_like(a), "async_out")
+    out_sync = DeviceTensor.from_numpy(np.empty_like(a), "sync_out")
+
+    kernel = DeviceKernel.compile_and_load(add_kernel, a, b)
+
+    in_name0, in_name1 = list(kernel.input_tensors_info)[:2]
+    out_name = list(kernel.output_tensors_info)[0]
+    inputs = {in_name0: da, in_name1: db}
+
+    fut = kernel.submit(inputs=inputs, outputs={out_name: out_async})
+    fut.wait()  # block until the submission completes before reading back
+
+    kernel(inputs=inputs, outputs={out_name: out_sync})
+
+    # Async path matches both the sync path and the numpy reference.
+    np.testing.assert_array_equal(out_async.numpy(), out_sync.numpy())
+    np.testing.assert_allclose(out_async.numpy(), a + b, rtol=1e-2, atol=1e-2)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])


### PR DESCRIPTION
## What

Adds a non-blocking execute path to `DeviceKernel` so the host can pipeline kernel submissions instead of blocking on every kernel, and wires it into the gpt-oss-20b example.

The non-blocking path is built on `SpikeAsync` (the existing async runtime) rather than a bespoke bookkeeping layer: `submit()` returns a `SpikeAsyncFuture` and completion is awaited via `future.wait()`.

### API (`nkipy.runtime`)
- **`DeviceKernel.submit(inputs, outputs) -> SpikeAsyncFuture`** — validate I/O (parity with `__call__`), build tensor sets, and enqueue the kernel on the runtime's FIFO compute channel via the singleton-backed `SpikeAsync`, returning immediately. FIFO ordering preserves data dependencies between successive submissions.
- **`future.wait()`** — block for that submission to complete before reading its outputs back to host. To cap the in-flight window (the compute queue has finite depth), keep the futures and `.wait()` on the oldest before submitting past your window.

Validation happens up front, so name/shape/dtype/core mismatches raise at the submission site instead of surfacing as an opaque NRT failure out of `wait()`.

### `spike`
- `SpikeAsync.__init__` gains an optional `spike=` arg to wrap an existing `Spike` instead of constructing its own (backward compatible; default unchanged).
- **`get_spike_async_singleton()`** lazily wraps the one process `Spike` singleton in a single `SpikeAsync` view, so blockingly-loaded models/tensors can be submitted non-blockingly without standing up a second NRT runtime. Only async callers construct it; `reset()` drops it alongside the `Spike` it wraps. It resolves the `Spike` singleton **before** taking the module lock, since `_lock` is non-reentrant and `get_spike_singleton()`'s init path re-acquires it (holding it across that call self-deadlocks).

### Example integration (gpt-oss-20b)
Opt-in async decode via `GPT_OSS_ASYNC=1` (`GPT_OSS_ASYNC_WINDOW` caps in-flight ops, default 4); default behavior unchanged. Per token the tkg layer stack + sampling are submitted non-blocking with a bounded window (wait on the oldest future when full), then **all outstanding futures are drained in FIFO order** before reading `next_id` back. Draining every future — not just the last — surfaces a failed submission from its own `.wait()` instead of hanging FIFO behind it, and leaves no completed-with-exception future unretrieved. I/O building is factored into `_layer_io`/`_sampling_io` so the sync and async paths share it.

## Testing
- New unit tests cover the `submit` wrapper glue with a fake `SpikeAsync` (tensor-set construction + future return, and up-front validation short-circuit), plus a device-gated round-trip that asserts `submit()+wait()` produces the same output as the blocking `__call__` path.
- Verified on trn2 (4 ranks, batch=1): decode **~41 -> ~68 tok/s (~1.7x)**, byte-identical output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
